### PR TITLE
Assure /tmp is writable when rootfs is read-only

### DIFF
--- a/images/trustx-cml-initramfs.bb
+++ b/images/trustx-cml-initramfs.bb
@@ -50,6 +50,8 @@ update_fstab () {
     mkdir -p ${IMAGE_ROOTFS}/data
     cat >> ${IMAGE_ROOTFS}/etc/fstab <<EOF
 
+tmpfs /tmp tmpfs defaults 0 0
+
 /dev/disk/by-partlabel/boot /boot vfat umask=0077 0 1 
 /dev/disk/by-partlabel/data /data btrfs defaults   0 0 
 /dev/disk/by-partlabel/modules /lib/modules/${KERNELVERSION} squashfs defaults 0 0


### PR DESCRIPTION
Assure writable /tmp directory on read-only rootfs