### PR TITLE
Proper fstab and init script for cml

### DIFF
--- a/images/trustx-cml-initramfs.bb
+++ b/images/trustx-cml-initramfs.bb
@@ -53,18 +53,6 @@ IMAGE_ROOTFS_SIZE = "4096"
 
 KERNELVERSION="$(cat "${STAGING_KERNEL_BUILDDIR}/kernel-abiversion")"
 
-update_fstab () {
-
-    mkdir -p ${IMAGE_ROOTFS}/data
-    cat >> ${IMAGE_ROOTFS}/etc/fstab <<EOF
-
-tmpfs /tmp tmpfs defaults 0 0
-
-/dev/disk/by-label/boot /boot vfat umask=0077 0 1
-/dev/disk/by-label/trustme /mnt ext4 defaults 0 0
-EOF
-}
-
 update_inittab () {
     echo "tty12::respawn:${base_sbindir}/mingetty --autologin root tty12" >> ${IMAGE_ROOTFS}/etc/inittab
 
@@ -83,7 +71,6 @@ update_hostname () {
     echo "trustx-cml" > ${IMAGE_ROOTFS}/etc/hostname
 }
 
-ROOTFS_POSTPROCESS_COMMAND_append = " update_fstab; "
 ROOTFS_POSTPROCESS_COMMAND_append = " update_modules_dep; "
 ROOTFS_POSTPROCESS_COMMAND_append = " update_hostname; "
 

--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -19,26 +19,23 @@ mount -t proc proc /proc
 mount -t sysfs sysfs /sys
 mount -t devtmpfs none /dev
 
+mkdir -p /dev/pts
+mount -t devpts devpts /dev/pts
+
 # do not log kernel messages to console
 echo 1 > /proc/sys/kernel/printk
 
 mkdir -p /dev/shm
 mkdir -p /run
 mkdir -p /var/run
+mkdir -p /data
 
 udevd --daemon
 
 udevadm trigger --action=add
 udevadm settle 
 
-sleep 5
-
 mount -a
-
-sleep 5
-
-mount --bind /mnt/modules /lib/modules
-mount --bind /mnt/userdata /data
 
 mkdir -p /data/logs
 
@@ -49,11 +46,6 @@ udevadm settle
 modprobe loop
 modprobe btrfs
 modprobe vport-gre
-
-if [ -e "/dev/disk/by-label/containers" ]; then
-	echo "Found dedicated filesystem for containers, mounting it!"
-	mount /dev/disk/by-label/containers /data/cml/containers
-fi
 
 if [ ! -f "/data/cml/containers/00000000-0000-0000-0000-000000000000.conf" ]; then
 	cp /data/cml/containers_templates/00000000-0000-0000-0000-000000000000.conf /data/cml/containers/00000000-0000-0000-0000-000000000000.conf

--- a/recipes-poky/base-files/base-files/fstab
+++ b/recipes-poky/base-files/base-files/fstab
@@ -1,0 +1,16 @@
+# initial mounts are done in cml-boot init script
+
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+
+tmpfs                /tmp                 tmpfs      defaults              0  0
+
+LABEL=boot           /boot                vfat       umask=0077            0  1
+LABEL=trustme        /mnt                 ext4       defaults              0  0
+
+/mnt/modules         /lib/modules         none       bind                  0  0
+/mnt/userdata        /data                none       bind                  0  0
+
+LABEL=containers     /data/cml/containers btrfs      defaults,nofail       0  0

--- a/recipes-poky/base-files/base-files_%.bbappend
+++ b/recipes-poky/base-files/base-files_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_append := '${@bb.utils.contains("INITRAMFS_IMAGE", [ 'trustx-cml-initramfs' ], ":${THISDIR}/${PN}", "",d)}'

--- a/recipes-poky/busybox/busybox-inittab/inittab
+++ b/recipes-poky/busybox/busybox-inittab/inittab
@@ -1,0 +1,17 @@
+# This is run first except when booting in single-user mode.
+
+# We assume mount's are done in init script by cml-boot
+
+::sysinit:/etc/init.d/rcS
+
+# Stuff to do before rebooting
+::ctrlaltdel:/sbin/reboot
+::shutdown:/etc/init.d/rcK
+::shutdown:/sbin/swapoff -a
+::shutdown:/bin/umount -a -r
+
+# Stuff to do when restarting the init process
+::restart:/sbin/init
+
+# set hostname
+null::sysinit:/bin/busybox hostname -F /etc/hostname

--- a/recipes-poky/busybox/busybox-inittab_%.bbappend
+++ b/recipes-poky/busybox/busybox-inittab_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_append := '${@bb.utils.contains("INITRAMFS_IMAGE", [ 'trustx-cml-initramfs' ], ":${THISDIR}/${PN}", "",d)}'


### PR DESCRIPTION
This commit fixes race condition between busybox init
and cmld mounting toofs read-only. Further, CML-specific labeled
partitions are now properly defined in fstab and are mounted by
init script with mount -a. This makes the sleeps in init script
obsolete.