### PR TITLE
cml-boot: Fixed udevd start and proper fstab

### DIFF
--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -14,20 +14,20 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 
 mkdir -p /proc
 mkdir -p /sys
+mkdir -p /run
 
-mount -t proc proc /proc
-mount -t sysfs sysfs /sys
-mount -t devtmpfs none /dev
+mount /proc
+mount /sys
+mount /dev
+mount /run
 
 mkdir -p /dev/pts
-mount -t devpts devpts /dev/pts
+mount /dev/pts
 
 # do not log kernel messages to console
 echo 1 > /proc/sys/kernel/printk
 
 mkdir -p /dev/shm
-mkdir -p /run
-mkdir -p /var/run
 mkdir -p /data
 
 udevd --daemon
@@ -46,6 +46,8 @@ udevadm settle
 modprobe loop
 modprobe btrfs
 modprobe vport-gre
+
+mount -a
 
 if [ ! -f "/data/cml/containers/00000000-0000-0000-0000-000000000000.conf" ]; then
 	cp /data/cml/containers_templates/00000000-0000-0000-0000-000000000000.conf /data/cml/containers/00000000-0000-0000-0000-000000000000.conf
@@ -87,9 +89,4 @@ echo "Starting Compartment Manger Daemon (cmld)"
 cmld &
 echo "-- cml debug console on tty12 [ready]" > /dev/console
 
-
-udevadm control --exit
-
-
-rm -f /usr/share/X11/xorg.conf.d/90-evdev.conf
 exec /sbin/init > /dev/$LOGTTY 2>&1

--- a/recipes-poky/base-files/base-files/fstab
+++ b/recipes-poky/base-files/base-files/fstab
@@ -1,16 +1,18 @@
 # initial mounts are done in cml-boot init script
 
-proc                 /proc                proc       defaults              0  0
+proc                 /proc                proc       nosuid,nodev,noexec   0  0
+sysfs                /sys                 sysfs      nosuid,nodev,noexec   0  0
+devtmpfs             /dev                 devtmpfs   mode=0755,nosuid      0  0
 devpts               /dev/pts             devpts     mode=0620,gid=5       0  0
 tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
-tmpfs                /var/volatile        tmpfs      defaults              0  0
+tmpfs                /var/volatile        tmpfs      nosuid,nodev,noexec   0  0
 
 tmpfs                /tmp                 tmpfs      defaults              0  0
 
 LABEL=boot           /boot                vfat       umask=0077            0  1
-LABEL=trustme        /mnt                 ext4       defaults              0  0
+LABEL=trustme        /mnt                 ext4       nosuid,nodev,noexec   0  0
 
-/mnt/modules         /lib/modules         none       bind                  0  0
-/mnt/userdata        /data                none       bind                  0  0
+/mnt/modules         /lib/modules         none       bind,nosuid,nodev,noexec 0  0
+/mnt/userdata        /data                none       bind,nosuid,nodev,noexec 0  0
 
-LABEL=containers     /data/cml/containers btrfs      defaults,nofail       0  0
+LABEL=containers     /data/cml/containers btrfs      nosuid,nodev,noexec,nofail 0  0


### PR DESCRIPTION
This patch starts udevd after /run is mounted, thus preventing
sockets created on wrong file system. Further, udevd is not
destroyed anymore since it is needed for udev events in cmld
uevent subsystem now. The fstab was fixed accordingly with
more restrictive mount options.