### PR TITLE
Provide modules and firmware as loop mounted squashfs images

### DIFF
--- a/classes/trustmegeneric.bbclass
+++ b/classes/trustmegeneric.bbclass
@@ -36,8 +36,8 @@ TRUSTME_GENERIC_DEPENDS = " \
     dosfstools-native:do_populate_sysroot \
     gptfdisk-native:do_populate_sysroot \
     trustx-cml-initramfs:do_image_complete \
+    trustx-cml-firmware:do_image_complete \
     virtual/kernel:do_deploy \
-	linux-firmware:do_package_write_ipk \
 "
 
 
@@ -179,32 +179,11 @@ if [ -z "${TRUSTME_CONTAINER_ARCH_${MACHINE}}" ];then
 	fi
 
 	# copy modules to data partition directory
-	cp -fL "${DEPLOY_DIR_IMAGE}/cml-kernel/modules-${MODULE_TARBALL_LINK_NAME}.tgz" "${tmp_modules}/modules.tgz"
-	ls -l "${tmp_modules}"
-	tar -C "${tmp_modules}/" -xf "${tmp_modules}/modules.tgz"
-	kernelabiversion="$(cat "${STAGING_KERNEL_BUILDDIR}/kernel-abiversion")"
-	#kernelabiversion="${KERNELVERSION}"
-	rm -f "${tmp_modules}/modules.tgz"
-	bbnote "Updating modules dependencies for kernel $kernelabiversion"
-	sh -c "cd \"${tmp_modules}\" && depmod --basedir \"${tmp_modules}\" ${kernelabiversion}"
-	cp -fr "${tmp_modules}/lib/modules" "${tmp_datapart}"
+	cp -fL "${DEPLOY_DIR_IMAGE}/cml-kernel/modules-${MODULE_TARBALL_LINK_NAME}.squashfs" "${tmp_datapart}/modules.img"
 
 	# copy firmware to data partition directory
 	bbnote "Copying linux-firmware"
-	package_names="$(ls ${DEPLOY_DIR_IPK}/all/ | grep 'linux-firmware')"
-
-	if [ -z package_names ]; then
-		bbfatal "Unable to locate linux-firmware ipk. was target linux-firmware built?"
-	fi
-
-	for package in $package_names
-	do
-		cp "${DEPLOY_DIR_IPK}/all/$package" "${tmp_firmware}/firmware.ipk"
-		cd "${tmp_firmware}"
-		ar x firmware.ipk
-		tar -xf data.tar.xz
-	done
-	cp -r "${tmp_firmware}/lib/firmware" "${tmp_datapart}"
+	cp -fL "${DEPLOY_DIR_IMAGE}/trustx-cml-firmware-${MACHINE}.squashfs" "${tmp_datapart}/firmware.img"
 
 	# copy trustme files to image deploy dir
 	cp -afr "${tmp_datapart}/." "${TRUSTME_IMAGE_OUT}/trustme_datapartition"

--- a/images/trustx-cml-firmware.bb
+++ b/images/trustx-cml-firmware.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Firmware Image for CML."
+
+PACKAGE_INSTALL = "linux-firmware"
+IMAGE_INSTALL = ""
+IMAGE_LINGUAS = ""
+ROOTFS_BOOTSTRAP_INSTALL = ""
+
+IMAGE_FSTYPES = "squashfs"
+
+IMAGE_FEATURES_remove += "package-management"
+
+inherit image
+
+move_firmware() {
+	mv ${IMAGE_ROOTFS}/lib/firmware ${IMAGE_ROOTFS}/firmware
+}
+
+cleanup_root() {
+	rm -rf ${IMAGE_ROOTFS}/etc
+	rm -rf ${IMAGE_ROOTFS}/run
+	rm -rf ${IMAGE_ROOTFS}/var
+	rmdir ${IMAGE_ROOTFS}/lib
+}
+
+ROOTFS_POSTPROCESS_COMMAND_append = " move_firmware; "
+IMAGE_PREPROCESS_COMMAND_append = " cleanup_root; "

--- a/recipes-kernel/linux/linux-%.bbappend
+++ b/recipes-kernel/linux/linux-%.bbappend
@@ -1,0 +1,13 @@
+DEPENDS += "squashfs-tools-native"
+
+MODULE_IMAGE_SUFFIX = "squashfs"
+
+kernel_do_deploy_append() {
+	if (grep -q -i -e '^CONFIG_MODULES=y$' .config); then
+		kernelabiversion="$(cat "${STAGING_KERNEL_BUILDDIR}/kernel-abiversion")"
+		bbnote "Updating modules dependencies for kernel $kernelabiversion"
+		sh -c "cd \"${D}${root_prefix}\" && depmod --basedir \"${D}${root_prefix}\" ${kernelabiversion}"
+		mksquashfs ${D}${root_prefix}/lib/modules $deployDir/modules-${MODULE_TARBALL_NAME}.${MODULE_IMAGE_SUFFIX}
+		ln -sf modules-${MODULE_TARBALL_NAME}.${MODULE_IMAGE_SUFFIX} $deployDir/modules-${MODULE_TARBALL_LINK_NAME}.${MODULE_IMAGE_SUFFIX}
+	fi
+}

--- a/recipes-poky/base-files/base-files/fstab
+++ b/recipes-poky/base-files/base-files/fstab
@@ -12,8 +12,8 @@ tmpfs                /tmp                 tmpfs      defaults              0  0
 LABEL=boot           /boot                vfat       umask=0077            0  1
 LABEL=trustme        /mnt                 ext4       nosuid,nodev,noexec   0  0
 
-/mnt/modules         /lib/modules         none       bind,nosuid,nodev,noexec 0  0
-/mnt/firmware        /lib/firmware        none       bind,nosuid,nodev,noexec 0  0
+/mnt/modules.img     /lib/modules         squashfs   loop,nosuid,nodev,noexec 0  0
+/mnt/firmware.img    /lib/firmware        squashfs   loop,nosuid,nodev,noexec 0  0
 /mnt/userdata        /data                none       bind,nosuid,nodev,noexec 0  0
 
 LABEL=containers     /data/cml/containers btrfs      nosuid,nodev,noexec,nofail 0  0


### PR DESCRIPTION
To ease kernel updates, this patch introduces a new image for
firmware files and modifies the kernel recipes to produce a squashfs
image with all modules. The fstab and trustmegeneric.bbclass is
adopted to use the new images instead of just directories in /data.