### PR TITLE
sc-hsm-embedded: switch to versioned built from upstream

### DIFF
--- a/images/trustx-cml-initramfs.bb
+++ b/images/trustx-cml-initramfs.bb
@@ -18,7 +18,7 @@ PACKAGE_INSTALL = "\
 	rattestation \
 	stunnel \
 	openssl-tpm2-engine \
-	sc-hsm-cardservice \
+	sc-hsm-embedded \
 	e2fsprogs-mke2fs \
 	e2fsprogs-e2fsck \
 	btrfs-tools \

--- a/recipes-sc-hsm-cardservice/sc-hsm-cardservice/files/0001-build-a-cardservice-library.patch
+++ b/recipes-sc-hsm-cardservice/sc-hsm-cardservice/files/0001-build-a-cardservice-library.patch
@@ -1,0 +1,70 @@
+From 9646433d2ffd6200d4f2175f174a5df48f2c069e Mon Sep 17 00:00:00 2001
+From: ceppleaisec <56912581+ceppleaisec@users.noreply.github.com>
+Date: Mon, 6 Apr 2020 17:48:31 +0200
+Subject: [PATCH 1/1] build a cardservice library
+
+---
+ src/ctccid/Makefile.am                           |  1 +
+ src/examples/key-generator/Makefile.am           | 16 ++++++++++++++--
+ .../key-generator/libcardservice.exports         |  9 +++++++++
+ 3 files changed, 24 insertions(+), 2 deletions(-)
+ create mode 100644 src/examples/key-generator/libcardservice.exports
+
+diff --git a/src/ctccid/Makefile.am b/src/ctccid/Makefile.am
+index f62468b..f9bada3 100644
+--- a/src/ctccid/Makefile.am
++++ b/src/ctccid/Makefile.am
+@@ -1,6 +1,7 @@
+ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+ 
+ lib_LTLIBRARIES = libctccid.la
++include_HEADERS = ctapi.h
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src $(LIBUSB_CFLAGS) -pthread
+ 
+diff --git a/src/examples/key-generator/Makefile.am b/src/examples/key-generator/Makefile.am
+index c44629f..422e4ae 100644
+--- a/src/examples/key-generator/Makefile.am
++++ b/src/examples/key-generator/Makefile.am
+@@ -3,9 +3,21 @@ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+ if ENABLE_CTAPI
+ noinst_PROGRAMS = key-generator
+ 
++lib_LTLIBRARIES = libcardservice.la
++include_HEADERS = sc-hsm-cardservice.h
++
++#libcardservice_la_LIBADD = $(top_builddir)/src/ctccid/libctccid.la
++libcardservice_la_SOURCES = sc-hsm-cardservice.c
++
++libcardservice_la_LDFLAGS = $(AM_LDFLAGS) \
++			    $(top_builddir)/src/common/libcommon.la \
++		            -export-symbols "$(srcdir)/libcardservice.exports" \
++	                    -module -shared -avoid-version -no-undefined -pthread
++
+ AM_CPPFLAGS = -I$(top_srcdir)/src
+ 
+-key_generator_SOURCES = key-generator.c sc-hsm-cardservice.c
++key_generator_SOURCES = key-generator.c
+ 
+-key_generator_LDADD = $(top_builddir)/src/ctccid/libctccid.la
++key_generator_LDADD = $(top_builddir)/src/ctccid/libctccid.la \
++		      libcardservice.la
+ endif
+diff --git a/src/examples/key-generator/libcardservice.exports b/src/examples/key-generator/libcardservice.exports
+new file mode 100644
+index 0000000..aec9e09
+--- /dev/null
++++ b/src/examples/key-generator/libcardservice.exports
+@@ -0,0 +1,9 @@
++processAPDU
++selectHSM
++initializeDevice
++queryPIN
++verifyPIN
++changePIN
++generateSymmetricKey
++writeKeyDescription
++deriveKey
+-- 
+2.20.1
+

--- a/recipes-sc-hsm-cardservice/sc-hsm-cardservice/files/0002-Fix-includes-for-MUSL-builds.patch
+++ b/recipes-sc-hsm-cardservice/sc-hsm-cardservice/files/0002-Fix-includes-for-MUSL-builds.patch
@@ -1,0 +1,34 @@
+From c5bf032a441db13a5b295f2d3414a3d99d9e1cc0 Mon Sep 17 00:00:00 2001
+From: Christian Epple <christian.epple@aisec.fraunhofer.de>
+Date: Fri, 5 Feb 2021 10:03:59 +0100
+Subject: [PATCH 1/1] Fix includes for MUSL builds
+
+Make sure unistd.h is included also when sc-hsm-embedded is configured to be used with --enable-ctapi
+---
+ src/pkcs11/p11generic.h | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/pkcs11/p11generic.h b/src/pkcs11/p11generic.h
+index e87b0f0..3e3b71b 100644
+--- a/src/pkcs11/p11generic.h
++++ b/src/pkcs11/p11generic.h
+@@ -50,12 +50,14 @@
+ #define _MAX_PATH FILENAME_MAX
+ #endif
+ 
++#ifndef _WIN32
++#include <unistd.h>
++#endif
++
+ #ifndef CTAPI
+ #ifdef _WIN32
+ #include <winscard.h>
+ #define  MAX_READERNAME   128
+-#else
+-#include <unistd.h>
+ #ifdef __APPLE__
+ #include <PCSC/pcsclite.h>
+ #include <PCSC/winscard.h>
+-- 
+2.20.1
+

--- a/recipes-sc-hsm-cardservice/sc-hsm-cardservice/sc-hsm-embedded_2.11.bb
+++ b/recipes-sc-hsm-cardservice/sc-hsm-cardservice/sc-hsm-embedded_2.11.bb
@@ -9,19 +9,27 @@
 # represented as "Unknown" below, you will need to check them yourself:
 #   COPYING
 SUMMARY = "Light-weight PKCS#11 library for using the SmartCard-HSM"
-DESCRIPTION = "This module has been initially developed to support the integration of a SmartCard-HSM in embedded systems with a little footprint. Rather than using a PC/SC daemon to manage attached card readers and token, the smaller Card Terminal API (CT-API) can be used."
+DESCRIPTION = "This module has been initially developed to support the \
+integration of a SmartCard-HSM in embedded systems with a little footprint. \
+Rather than using a PC/SC daemon to manage attached card readers and token, \
+the smaller Card Terminal API (CT-API) can be used."
+
 HOMEPAGE = "https://github.com/CardContact/sc-hsm-embedded"
 # SECTION = ""
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=55b854a477953696452f698a3af5de1c"
 
-SRC_URI = "git://github.com/trustm3/sc-hsm-embedded.git;protocol=https;branch=build_cardservice_lib"
+SRC_URI = " https://github.com/CardContact/sc-hsm-embedded/archive/V${PV}.tar.gz "
 
-# Modify these as desired
-PV = "2.10+git${SRCPV}"
-SRCREV = "${AUTOREV}"
+SRC_URI[md5sum] = "ed3d9c715da5f6e20efce7b375dacdd0"
+SRC_URI[sha256sum] = "3a9a3a1247c43e075e1aab75e84cf910ea8a73b04c7339f579e0dfbce62917dd"
 
-S = "${WORKDIR}/git"
+SRC_URI_append = " \
+	file://0001-build-a-cardservice-library.patch;patch=1 \
+	file://0002-Fix-includes-for-MUSL-builds.patch;patch=1 \
+"
+
+S = "${WORKDIR}/${BPN}-${PV}"
 
 # force *.so into main package (see https://www.yoctoproject.org/pipermail/yocto/2017-August/037581.html)
 # to resolve "do_package_qa: QA Issue: -dev package contains non-symlink .so" error
@@ -39,4 +47,4 @@ DEPENDS = "openssl librepo libusb1"
 inherit pkgconfig autotools
 
 # Specify any options you want to pass to the configure script using EXTRA_OECONF:
-EXTRA_OECONF = "--enable-ctapi --enable-debug"
+EXTRA_OECONF = "--enable-ctapi"

--- a/recipes-sc-hsm-cardservice/sc-hsm-cardservice/sc-hsm-embedded_2.11.bb
+++ b/recipes-sc-hsm-cardservice/sc-hsm-cardservice/sc-hsm-embedded_2.11.bb
@@ -19,17 +19,14 @@ HOMEPAGE = "https://github.com/CardContact/sc-hsm-embedded"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=55b854a477953696452f698a3af5de1c"
 
-SRC_URI = " https://github.com/CardContact/sc-hsm-embedded/archive/V${PV}.tar.gz "
-
-SRC_URI[md5sum] = "ed3d9c715da5f6e20efce7b375dacdd0"
-SRC_URI[sha256sum] = "3a9a3a1247c43e075e1aab75e84cf910ea8a73b04c7339f579e0dfbce62917dd"
+SRC_URI = " git://github.com/CardContact/sc-hsm-embedded.git;protocol=https;tag=V2.11"
 
 SRC_URI_append = " \
 	file://0001-build-a-cardservice-library.patch;patch=1 \
 	file://0002-Fix-includes-for-MUSL-builds.patch;patch=1 \
 "
 
-S = "${WORKDIR}/${BPN}-${PV}"
+S = "${WORKDIR}/git"
 
 # force *.so into main package (see https://www.yoctoproject.org/pipermail/yocto/2017-August/037581.html)
 # to resolve "do_package_qa: QA Issue: -dev package contains non-symlink .so" error

--- a/recipes-trustx/cmld/cmld_git.bb
+++ b/recipes-trustx/cmld/cmld_git.bb
@@ -23,7 +23,7 @@ INSANE_SKIP_tpm2d = "ldflags"
 INSANE_SKIP_control = "ldflags"
 INSANE_SKIP_rattestation = "ldflags"
 
-DEPENDS = "protobuf-c-native protobuf-c libselinux protobuf-c-text libcap e2fsprogs openssl ibmtss2 sc-hsm-cardservice"
+DEPENDS = "protobuf-c-native protobuf-c libselinux protobuf-c-text libcap e2fsprogs openssl ibmtss2 sc-hsm-embedded"
 
 EXTRA_OEMAKE = "TRUSTME_HARDWARE=${TRUSTME_HARDWARE}"
 EXTRA_OEMAKE += "TRUSTME_SCHSM=${TRUSTME_SCHSM}"


### PR DESCRIPTION
Use upstream sc-hsm-embedded sources and patch them as needed
instead of using a dedicated fork.