### PR TITLE
Enable usage of external btrfs as /data

### DIFF
--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -101,6 +101,23 @@ fi
 
 mount -a
 
+mkdir -p /mnt/extdata
+mount LABEL=extdata -o nosuid,nodev,noexec,nofail /mnt/extdata
+if [ $? -eq 0 ]
+then
+	mkdir -p /mnt/extdata/workdir
+	mkdir -p /mnt/extdata/data
+	mount -t overlay overlay -o lowerdir=/mnt/userdata,upperdir=/mnt/extdata/data,workdir=/mnt/extdata/workdir /data
+	if [ $? -ne 0 ]
+	then
+		echo "WARN: Failed to mount external data as overlayfs"
+		mount -o bind,nosuid,nodev,noexec /mnt/userdata /data
+	fi
+else
+	echo "No extdata fs supplied"
+	mount -o bind,nosuid,nodev,noexec /mnt/userdata /data
+fi
+
 mkdir -p /data/logs
 
 #now modules partition is mounted

--- a/recipes-poky/base-files/base-files/fstab
+++ b/recipes-poky/base-files/base-files/fstab
@@ -14,6 +14,5 @@ LABEL=trustme        /mnt                 ext4       nosuid,nodev,noexec   0  0
 
 /mnt/modules.img     /lib/modules         squashfs   loop,nosuid,nodev,noexec 0  0
 /mnt/firmware.img    /lib/firmware        squashfs   loop,nosuid,nodev,noexec 0  0
-/mnt/userdata        /data                none       bind,nosuid,nodev,noexec 0  0
 
 LABEL=containers     /data/cml/containers btrfs      nosuid,nodev,noexec,nofail 0  0


### PR DESCRIPTION
Allow usage of externally provided 9p btrfs to be mounted
as overlay over /mnt/userdata to /data. This enables the user
i.a. to work with larger guestsOSes in a virtualized environment.