### PR TITLE
cml-boot/files/cml-boot-script.stub: wait for boot partition

### DIFF
--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -50,6 +50,12 @@ sleep 2
 udevadm settle
 
 if [ -e "/dev/tpm0" ]; then
+	echo "Waiting for '/dev/disk/by-label/boot' "
+	while [ ! -e /dev/disk/by-label/boot ]; do
+		echo -n "."
+		sleep 1
+	done
+
 	CRYPTO_HDD=$(basename $(readlink /dev/disk/by-label/trustme))
 	BOOT_HDD=$(basename $(readlink /dev/disk/by-label/boot))
 


### PR DESCRIPTION
Wait untill '/dev/disk/by-label/boot' will appear in file system.
This should fix a race which may lead to an wrong device name for
for file system encryption of the trustme partition.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>