### PR TITLE
cml-boot: Fix extdata mount

### DIFF
--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -126,7 +126,7 @@ fi
 mount -a
 
 mkdir -p /mnt/extdata
-mount LABEL=extdata -o nosuid,nodev,noexec,nofail /mnt/extdata
+mount LABEL=extdata -o nosuid,nodev,noexec /mnt/extdata
 if [ $? -eq 0 ]
 then
 	mkdir -p /mnt/extdata/workdir


### PR DESCRIPTION
This commit fixes a bug that leads to an erroneous mount of
an overlayfs on /data.
The mount command must not be invoked with the "nofail" option in
the cml-boot script.

Signed-off-by: Christian Epple <christian.epple@aisec.fraunhofer.de>