### PR TITLE
images/trustx-core: enable pam for audit

### DIFF
--- a/images/trustx-core.bb
+++ b/images/trustx-core.bb
@@ -11,7 +11,7 @@ IMAGE_FSTYPES = "squashfs ext4"
 
 IMAGE_FEATURES_append = " allow-empty-password"
 IMAGE_FEATURES_append = " empty-root-password"
-IMAGE_FEATURES_append = " ssh-server-dropbear"
+IMAGE_FEATURES_append = " ssh-server-openssh"
 IMAGE_INSTALL_append = " control"
 IMAGE_INSTALL_append = " openvswitch"
 IMAGE_INSTALL_append = " bridge-utils"
@@ -23,6 +23,7 @@ IMAGE_INSTALL_append = " usbutils"
 IMAGE_INSTALL_append = " tcpdump"
 IMAGE_INSTALL_append = " util-linux"
 IMAGE_INSTALL_append = " binutils"
+IMAGE_INSTALL_append = " shadow"
 
 CONFIGS_OUT = "${DEPLOY_DIR_IMAGE}/trustx-configs"
 

--- a/recipes-poky/pam/libpam_%.bbappend
+++ b/recipes-poky/pam/libpam_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG = "audit"


### PR DESCRIPTION
added bbappend to enable audit in libpam and added shadow to trustx-core
packes list. Further replaced dropbear by openssh server to also get the
pam_loginuid module in place.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>