### PR TITLE
recipes-trustx/service/service-static: build exec_cap_systime

### DIFF
--- a/recipes-trustx/service/service-static_git.bb
+++ b/recipes-trustx/service/service-static_git.bb
@@ -24,10 +24,12 @@ do_configure () {
 
 do_compile () {
         oe_runmake -C service service-static
+        oe_runmake -C service exec_cap_systime
 }
 
 do_install () {
         :
 	install -d ${D}${base_sbindir}/
 	install -m 0755 ${S}service/cml-service-container ${D}${base_sbindir}/
+	install -m 0755 ${S}service/exec_cap_systime ${D}${base_sbindir}/
 }


### PR DESCRIPTION
Also build and install exec_cap_systime which may be injected
during runtime into containers for testing the ability to execute
processes with host CAP_SYS_TIME in containers.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>