### PR TITLE
cml-boot: Do not start SCD

### DIFF
--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -171,27 +171,9 @@ for suffix in conf sig cert; do
 	fi
 done
 
-
-# if device.cert is not present, start scd to initialize device
 export PATH="/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
-if [ ! -f /data/cml/tokens/device.cert ]; then
-	echo "--- Provisioning/Installing Mode ---" > /etc/motd
-	echo "Starting Security Helpder Daemon (scd) in Provisioning Mode"
-	scd
-	echo "--- Provisioning/Installing Mode ---" > /dev/console
-fi
 
-echo "Starting Security Helpder Daemon (scd)"
-scd &
-if [ ! -S /run/socket/cml-scd-control ]; then
-	echo "Waiting for scd's control interface"
-fi
-while [ ! -S /run/socket/cml-scd-control ]; do
-	echo -n "."
-	sleep 1
-done
-
-echo "Starting Compartment Manger Daemon (cmld)"
+echo "Starting Compartment Manager Daemon (cmld)"
 cmld &
 echo "-- cml debug console on tty12 [ready]" > /dev/console
 


### PR DESCRIPTION
The SCD is now started by the CMLD

Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>