### PR TITLE
images/trustx-signing.inc: add missing python3 dependency

### DIFF
--- a/images/trustx-signing.inc
+++ b/images/trustx-signing.inc
@@ -12,7 +12,7 @@ CLEAN_GUEST_OUT ?= "1"
 
 TRUSTME_VERSION ?= "${@'${IMAGE_VERSION_SUFFIX}'.replace('-','')}"
 
-DEPENDS += " pki-native protobuf-native python-protobuf-native python3-protobuf-native protobuf-c-native cmld"
+DEPENDS += " pki-native python3-native python-native protobuf-native python-protobuf-native python3-protobuf-native protobuf-c-native cmld"
 
 OS_NAME ?= "${PN}os"
 


### PR DESCRIPTION
This should finally fix builds in docker environment provided
by trustme/build repository.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>