### PR TITLE
trusted_connector: Upstream branch was deleted

### DIFF
--- a/recipes-trustx/trusted-connector/trusted-connector_git.bb
+++ b/recipes-trustx/trusted-connector/trusted-connector_git.bb
@@ -16,7 +16,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=86d3f3a95c324c9479bd8986968f4327"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-BRANCH = "develop"
+BRANCH = "master"
 SRCREV = "${AUTOREV}"
 
 PVBASE := "${PV}"


### PR DESCRIPTION
The upstream branch currently used in trusted_connector_git.bb was deleted.
As this causes all builds to fail, this commit changes the branch to the master branch.

It has to be tested, if this branch still works for the images depending on it.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>