### PR TITLE
images/trustx-cml-initramfs: fixed update_inittab in dev build

### DIFF
--- a/images/trustx-cml-initramfs.bb
+++ b/images/trustx-cml-initramfs.bb
@@ -62,8 +62,7 @@ update_inittab () {
     echo "tty12::respawn:${base_sbindir}/mingetty --autologin root tty12" >> ${IMAGE_ROOTFS}/etc/inittab
 
     mkdir -p ${IMAGE_ROOTFS}/dev
-    mknod -m 622 ${IMAGE_ROOTFS}/dev/console c 5 1
-    mknod -m 622 ${IMAGE_ROOTFS}/dev/tty12 c 4 1
+    mknod -m 622 ${IMAGE_ROOTFS}/dev/tty12 c 4 12
 }
 
 update_inittab_release () {


### PR DESCRIPTION
mknod for /dev/console is made by cml-boot recipe now. Thus, remove
it here from update_inittab image post processing command to avoid
EEXIST.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>