### PR TITLE
cmld_git: Add support for CC_MODE

### DIFF
--- a/recipes-trustx/cmld/cmld_git.bb
+++ b/recipes-trustx/cmld/cmld_git.bb
@@ -28,6 +28,7 @@ DEPENDS = "protobuf-c-native protobuf-c libselinux protobuf-c-text libcap e2fspr
 EXTRA_OEMAKE = "TRUSTME_HARDWARE=${TRUSTME_HARDWARE}"
 EXTRA_OEMAKE += "TRUSTME_SCHSM=${TRUSTME_SCHSM}"
 EXTRA_OEMAKE += "DEVELOPMENT_BUILD=${DEVELOPMENT_BUILD}"
+EXTRA_OEMAKE += "CC_MODE=${CC_MODE}"
 
 do_configure () {
     :


### PR DESCRIPTION
This commit adds support for the CC_MODE flag to cmld_git.bb

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>