### PR TITLE
recipes-trustx/{cmld|service}: switched to dunfell branch

### DIFF
--- a/recipes-trustx/cmld/cmld_git.bb
+++ b/recipes-trustx/cmld/cmld_git.bb
@@ -1,7 +1,7 @@
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-BRANCH = "zeus"
+BRANCH = "dunfell"
 SRCREV = "${AUTOREV}"
 
 PVBASE := "${PV}"

--- a/recipes-trustx/service/service-static_git.bb
+++ b/recipes-trustx/service/service-static_git.bb
@@ -1,7 +1,7 @@
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-BRANCH = "zeus"
+BRANCH = "dunfell"
 SRCREV = "${AUTOREV}"
 
 PVBASE := "${PV}"

--- a/recipes-trustx/service/service_git.bb
+++ b/recipes-trustx/service/service_git.bb
@@ -1,7 +1,7 @@
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-BRANCH = "zeus"
+BRANCH = "dunfell"
 SRCREV = "${AUTOREV}"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"


### PR DESCRIPTION
Switched the trustx recipes for cmld and service from zeus to dunfell.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>