### PR TITLE
trustx-signing.inc: Use certificate with RSA-PSS padding scheme

### DIFF
--- a/images/trustx-signing.inc
+++ b/images/trustx-signing.inc
@@ -39,7 +39,7 @@ do_sign_guestos () {
             -c ${GUESTS_OUT}/${OS_NAME}-${trustme_version}.conf \
             -i ${GUESTS_OUT}/${OS_NAME}-${trustme_version}/ -n ${OS_NAME}
     bash ${ENROLLMENT_DIR}/config_creator/sign_config.sh ${GUESTS_OUT}/${OS_NAME}-${trustme_version}.conf \
-            ${TEST_CERT_DIR}/ssig.key ${TEST_CERT_DIR}/ssig.cert
+            ${TEST_CERT_DIR}/ssig_cml.key ${TEST_CERT_DIR}/ssig_cml.cert
 
     rm ${ENROLLMENT_DIR}/config_creator/guestos_pb2.py*
 }


### PR DESCRIPTION
This commit adapts the trustx-signing.inc script
to the new structure of the test PKI.
Now, the certificate ssig_cml.cert is used to sign GuestOS
and container configuration files.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>