### PR TITLE
recipes-kernel/linux: added patch for dm-integrity audit events

### DIFF
--- a/recipes-kernel/linux/linux-vanilla/0001-dm-integrity-Generate-audit-events-for-integrity-vio.patch
+++ b/recipes-kernel/linux/linux-vanilla/0001-dm-integrity-Generate-audit-events-for-integrity-vio.patch
@@ -1,0 +1,291 @@
+From b1ee441aa5ca21a91b1f4e64151e94612bd94651 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Michael=20Wei=C3=9F?= <michael.weiss@aisec.fraunhofer.de>
+Date: Wed, 28 Jul 2021 17:35:23 +0200
+Subject: [PATCH] dm integrity: Generate audit events for integrity violations
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+dm-integrity signals integrity violations by returning I/O errors
+to user space. To identify integrity violations by a controlling
+instance, the kernel audit subsystem can be used to emit audit
+events to user space. We utilize this by introducing a new dm-audit
+submodule allowing to emit audit events on relevant io errors.
+Further, the construction of integrity device mappings are logged
+as audit events.
+
+Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>
+---
+ drivers/md/Makefile        |  4 ++
+ drivers/md/dm-audit.c      | 80 ++++++++++++++++++++++++++++++++++++++
+ drivers/md/dm-audit.h      | 33 ++++++++++++++++
+ drivers/md/dm-crypt.c      |  9 +++++
+ drivers/md/dm-integrity.c  | 13 ++++++-
+ include/uapi/linux/audit.h |  2 +
+ 6 files changed, 140 insertions(+), 1 deletion(-)
+ create mode 100644 drivers/md/dm-audit.c
+ create mode 100644 drivers/md/dm-audit.h
+
+diff --git a/drivers/md/Makefile b/drivers/md/Makefile
+index 6d3e234dc46a..643a4f047032 100644
+--- a/drivers/md/Makefile
++++ b/drivers/md/Makefile
+@@ -75,6 +75,10 @@ obj-$(CONFIG_DM_ERA)		+= dm-era.o
+ obj-$(CONFIG_DM_CLONE)		+= dm-clone.o
+ obj-$(CONFIG_DM_LOG_WRITES)	+= dm-log-writes.o
+ obj-$(CONFIG_DM_INTEGRITY)	+= dm-integrity.o
++ifeq ($(CONFIG_DM_INTEGRITY),y)
++obj-y				+= dm-audit.o
++endif
++
+ obj-$(CONFIG_DM_ZONED)		+= dm-zoned.o
+ obj-$(CONFIG_DM_WRITECACHE)	+= dm-writecache.o
+ 
+diff --git a/drivers/md/dm-audit.c b/drivers/md/dm-audit.c
+new file mode 100644
+index 000000000000..be22a43c24e7
+--- /dev/null
++++ b/drivers/md/dm-audit.c
+@@ -0,0 +1,80 @@
++/*
++ * Creating audit events for dm-integrity device.
++ *
++ * Copyright (C) 2021 Fraunhofer AISEC. All rights reserved.
++ *
++ * Authors: Michael Weiß <michael.weiss@aisec.fraunhofer.de>
++ */
++
++#include <linux/audit.h>
++#include <linux/device-mapper.h>
++#include <linux/bio.h>
++#include <linux/blkdev.h>
++
++#include "dm-audit.h"
++#include "dm-core.h"
++
++#ifdef CONFIG_AUDIT
++void dm_audit_log_ctr(const char *dm_msg_prefix, struct dm_target *ti,
++		      int result)
++{
++	struct audit_buffer *ab;
++	struct mapped_device *md = dm_table_get_md(ti->table);
++
++	if (audit_enabled == AUDIT_OFF)
++		return;
++
++	ab = audit_log_start(audit_context(), GFP_KERNEL, AUDIT_DM_INTEGRITY);
++	if (unlikely(!ab))
++		return;
++
++	audit_log_format(ab, "module=%s dev=%s op=ctr", dm_msg_prefix,
++			 dm_device_name(md));
++
++	if (!result)
++		audit_log_format(ab, " error_msg='%s'", ti->error);
++	audit_log_format(ab, " res=%d", result);
++	audit_log_end(ab);
++}
++
++void dm_audit_log_bio(const char *dm_msg_prefix, const char *op,
++		      struct bio *bio, sector_t sector, int result)
++{
++	struct audit_buffer *ab;
++
++	if (audit_enabled == AUDIT_OFF)
++		return;
++
++	ab = audit_log_start(audit_context(), GFP_KERNEL, AUDIT_DM_INTEGRITY);
++	if (unlikely(!ab))
++		return;
++
++	audit_log_format(ab, "module=%s dev=%d:%d op=%s", dm_msg_prefix,
++			 bio->bi_disk->major, bio->bi_disk->first_minor, op);
++
++	if (sector)
++		audit_log_format(ab, " sector=%llu",
++				 (unsigned long long)le64_to_cpu(sector));
++	audit_log_format(ab, " res=%d", result);
++	audit_log_end(ab);
++}
++
++void dm_audit_log_target(const char *dm_msg_prefix, const char *msg,
++			 struct dm_target *ti, int result)
++{
++	struct audit_buffer *ab;
++	struct mapped_device *md = dm_table_get_md(ti->table);
++
++	if (audit_enabled == AUDIT_OFF)
++		return;
++
++	ab = audit_log_start(audit_context(), GFP_KERNEL, AUDIT_DM_INTEGRITY);
++	if (unlikely(!ab))
++		return;
++
++	audit_log_format(ab, "module=%s dev=%s error_msg='%s' res=%d",
++			 dm_msg_prefix, dm_device_name(md), msg, result);
++
++	audit_log_end(ab);
++}
++#endif
+diff --git a/drivers/md/dm-audit.h b/drivers/md/dm-audit.h
+new file mode 100644
+index 000000000000..6b5cc1f21a15
+--- /dev/null
++++ b/drivers/md/dm-audit.h
+@@ -0,0 +1,33 @@
++/*
++ * Creating audit events for dm-integrity device.
++ *
++ * Copyright (C) 2021 Fraunhofer AISEC. All rights reserved.
++ *
++ * Authors: Michael Weiß <michael.weiss@aisec.fraunhofer.de>
++ */
++
++#include <linux/device-mapper.h>
++
++#ifdef CONFIG_AUDIT
++void dm_audit_log_bio(const char *dm_msg_prefix, const char *op,
++		      struct bio *bio, sector_t sector, int result);
++void dm_audit_log_target(const char *dm_msg_prefix, const char *msg,
++			 struct dm_target *ti, int result);
++void dm_audit_log_ctr(const char *dm_msg_prefix, struct dm_target *ti,
++		      int result);
++#else
++static inline void dm_audit_log_bio(const char *dm_msg_prefix, const char *op,
++				    struct bio *bio, sector_t sector,
++				    int result);
++{
++}
++static inline void dm_audit_log_target(const char *dm_msg_prefix,
++				       const char *msg, struct dm_target *ti,
++				       int result);
++{
++}
++static inline void dm_audit_log_ctr(const char *dm_msg_prefix,
++				    struct dm_target *ti, int result)
++{
++}
++#endif
+diff --git a/drivers/md/dm-crypt.c b/drivers/md/dm-crypt.c
+index 70ae6f3aede9..c4b31ef25b9e 100644
+--- a/drivers/md/dm-crypt.c
++++ b/drivers/md/dm-crypt.c
+@@ -40,6 +40,8 @@
+ 
+ #include <linux/device-mapper.h>
+ 
++#include "dm-audit.h"
++
+ #define DM_MSG_PREFIX "crypt"
+ 
+ /*
+@@ -1121,6 +1123,7 @@ static bool crypt_integrity_hmac(struct crypt_config *cc)
+ 	return crypt_integrity_aead(cc) && cc->key_mac_size;
+ }
+ 
++
+ /* Get sg containing data */
+ static struct scatterlist *crypt_get_sg_data(struct crypt_config *cc,
+ 					     struct scatterlist *sg)
+@@ -1363,6 +1366,8 @@ static int crypt_convert_block_aead(struct crypt_config *cc,
+ 		char b[BDEVNAME_SIZE];
+ 		DMERR_LIMIT("%s: INTEGRITY AEAD ERROR, sector %llu", bio_devname(ctx->bio_in, b),
+ 			    (unsigned long long)le64_to_cpu(*sector));
++		dm_audit_log_bio(DM_MSG_PREFIX, "convert-block-aead",
++				 ctx->bio_in, *sector, 0);
+ 	}
+ 
+ 	if (!r && cc->iv_gen_ops && cc->iv_gen_ops->post)
+@@ -2174,6 +2179,8 @@ static void kcryptd_async_done(struct crypto_async_request *async_req,
+ 		char b[BDEVNAME_SIZE];
+ 		DMERR_LIMIT("%s: INTEGRITY AEAD ERROR, sector %llu", bio_devname(ctx->bio_in, b),
+ 			    (unsigned long long)le64_to_cpu(*org_sector_of_dmreq(cc, dmreq)));
++		dm_audit_log_bio(DM_MSG_PREFIX, "convert-block-aead",
++				 ctx->bio_in, *org_sector_of_dmreq(cc, dmreq), 0);
+ 		io->error = BLK_STS_PROTECTION;
+ 	} else if (error < 0)
+ 		io->error = BLK_STS_IOERR;
+@@ -3326,9 +3333,11 @@ static int crypt_ctr(struct dm_target *ti, unsigned int argc, char **argv)
+ 	ti->num_flush_bios = 1;
+ 	ti->limit_swap_bios = true;
+ 
++	dm_audit_log_ctr(DM_MSG_PREFIX, ti, 1);
+ 	return 0;
+ 
+ bad:
++	dm_audit_log_ctr(DM_MSG_PREFIX, ti, 0);
+ 	crypt_dtr(ti);
+ 	return ret;
+ }
+diff --git a/drivers/md/dm-integrity.c b/drivers/md/dm-integrity.c
+index 4c7da1c4e6cb..4a2b7a863929 100644
+--- a/drivers/md/dm-integrity.c
++++ b/drivers/md/dm-integrity.c
+@@ -23,6 +23,8 @@
+ #include <linux/async_tx.h>
+ #include <linux/dm-bufio.h>
+ 
++#include "dm-audit.h"
++
+ #define DM_MSG_PREFIX "integrity"
+ 
+ #define DEFAULT_INTERLEAVE_SECTORS	32768
+@@ -378,8 +380,10 @@ static void dm_integrity_io_error(struct dm_integrity_c *ic, const char *msg, in
+ {
+ 	if (err == -EILSEQ)
+ 		atomic64_inc(&ic->number_of_mismatches);
+-	if (!cmpxchg(&ic->failed, 0, err))
++	if (!cmpxchg(&ic->failed, 0, err)) {
+ 		DMERR("Error on %s: %d", msg, err);
++		dm_audit_log_target(DM_MSG_PREFIX, msg, ic->ti, err);
++	}
+ }
+ 
+ static int dm_integrity_failed(struct dm_integrity_c *ic)
+@@ -1681,6 +1685,9 @@ static void integrity_metadata(struct work_struct *w)
+ 						    (sector - ((r + ic->tag_size - 1) / ic->tag_size)));
+ 					r = -EILSEQ;
+ 					atomic64_inc(&ic->number_of_mismatches);
++					dm_audit_log_bio(DM_MSG_PREFIX, "metadata", bio,
++						     (sector - ((r + ic->tag_size - 1) / ic->tag_size)), 0);
++
+ 				}
+ 				if (likely(checksums != checksums_onstack))
+ 					kfree(checksums);
+@@ -1884,6 +1891,8 @@ static bool __journal_read_write(struct dm_integrity_io *dio, struct bio *bio,
+ 
+ 					integrity_sector_checksum(ic, logical_sector, mem + bv.bv_offset, checksums_onstack);
+ 					if (unlikely(memcmp(checksums_onstack, journal_entry_tag(ic, je), ic->tag_size))) {
++						dm_audit_log_bio(DM_MSG_PREFIX, "journal-read-write", bio,
++								 logical_sector, 0);
+ 						DMERR_LIMIT("Checksum failed when reading from journal, at sector 0x%llx",
+ 							    logical_sector);
+ 					}
+@@ -4363,9 +4372,11 @@ static int dm_integrity_ctr(struct dm_target *ti, unsigned argc, char **argv)
+ 	if (ic->discard)
+ 		ti->num_discard_bios = 1;
+ 
++	dm_audit_log_ctr(DM_MSG_PREFIX, ti, 1);
+ 	return 0;
+ 
+ bad:
++	dm_audit_log_ctr(DM_MSG_PREFIX, ti, 0);
+ 	dm_integrity_dtr(ti);
+ 	return r;
+ }
+diff --git a/include/uapi/linux/audit.h b/include/uapi/linux/audit.h
+index cd2d8279a5e4..a75c261b1d62 100644
+--- a/include/uapi/linux/audit.h
++++ b/include/uapi/linux/audit.h
+@@ -140,6 +140,8 @@
+ #define AUDIT_MAC_CALIPSO_ADD	1418	/* NetLabel: add CALIPSO DOI entry */
+ #define AUDIT_MAC_CALIPSO_DEL	1419	/* NetLabel: del CALIPSO DOI entry */
+ 
++#define AUDIT_DM_INTEGRITY	1600	/* Audit DM-integrity events */
++
+ #define AUDIT_FIRST_KERN_ANOM_MSG   1700
+ #define AUDIT_LAST_KERN_ANOM_MSG    1799
+ #define AUDIT_ANOM_PROMISCUOUS      1700 /* Device changed promiscuous mode */
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla/5.4/0001-dm-report-suspended-device-during-destroy.patch
+++ b/recipes-kernel/linux/linux-vanilla/5.4/0001-dm-report-suspended-device-during-destroy.patch
@@ -1,0 +1,142 @@
+From adc0daad366b62ca1bce3e2958a40b0b71a8b8b3 Mon Sep 17 00:00:00 2001
+From: Mikulas Patocka <mpatocka@redhat.com>
+Date: Mon, 24 Feb 2020 10:20:28 +0100
+Subject: [PATCH] dm: report suspended device during destroy
+
+The function dm_suspended returns true if the target is suspended.
+However, when the target is being suspended during unload, it returns
+false.
+
+An example where this is a problem: the test "!dm_suspended(wc->ti)" in
+writecache_writeback is not sufficient, because dm_suspended returns
+zero while writecache_suspend is in progress.  As is, without an
+enhanced dm_suspended, simply switching from flush_workqueue to
+drain_workqueue still emits warnings:
+workqueue writecache-writeback: drain_workqueue() isn't complete after 10 tries
+workqueue writecache-writeback: drain_workqueue() isn't complete after 100 tries
+workqueue writecache-writeback: drain_workqueue() isn't complete after 200 tries
+workqueue writecache-writeback: drain_workqueue() isn't complete after 300 tries
+workqueue writecache-writeback: drain_workqueue() isn't complete after 400 tries
+
+writecache_suspend calls flush_workqueue(wc->writeback_wq) - this function
+flushes the current work. However, the workqueue may re-queue itself and
+flush_workqueue doesn't wait for re-queued works to finish. Because of
+this - the function writecache_writeback continues execution after the
+device was suspended and then concurrently with writecache_dtr, causing
+a crash in writecache_writeback.
+
+We must use drain_workqueue - that waits until the work and all re-queued
+works finish.
+
+As a prereq for switching to drain_workqueue, this commit fixes
+dm_suspended to return true after the presuspend hook and before the
+postsuspend hook - just like during a normal suspend. It allows
+simplifying the dm-integrity and dm-writecache targets so that they
+don't have to maintain suspended flags on their own.
+
+With this change use of drain_workqueue() can be used effectively.  This
+change was tested with the lvm2 testsuite and cryptsetup testsuite and
+the are no regressions.
+
+Fixes: 48debafe4f2f ("dm: add writecache target")
+Cc: stable@vger.kernel.org # 4.18+
+Reported-by: Corey Marthaler <cmarthal@redhat.com>
+Signed-off-by: Mikulas Patocka <mpatocka@redhat.com>
+Signed-off-by: Mike Snitzer <snitzer@redhat.com>
+---
+ drivers/md/dm-integrity.c  | 12 +++++-------
+ drivers/md/dm-writecache.c |  2 +-
+ drivers/md/dm.c            |  1 +
+ 3 files changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/md/dm-integrity.c b/drivers/md/dm-integrity.c
+index 2f98e88399ec..e1ad0b53f681 100644
+--- a/drivers/md/dm-integrity.c
++++ b/drivers/md/dm-integrity.c
+@@ -201,12 +201,13 @@ struct dm_integrity_c {
+ 	__u8 log2_blocks_per_bitmap_bit;
+ 
+ 	unsigned char mode;
+-	int suspending;
+ 
+ 	int failed;
+ 
+ 	struct crypto_shash *internal_hash;
+ 
++	struct dm_target *ti;
++
+ 	/* these variables are locked with endio_wait.lock */
+ 	struct rb_root in_progress;
+ 	struct list_head wait_list;
+@@ -2316,7 +2317,7 @@ static void integrity_writer(struct work_struct *w)
+ 	unsigned prev_free_sectors;
+ 
+ 	/* the following test is not needed, but it tests the replay code */
+-	if (READ_ONCE(ic->suspending) && !ic->meta_dev)
++	if (unlikely(dm_suspended(ic->ti)) && !ic->meta_dev)
+ 		return;
+ 
+ 	spin_lock_irq(&ic->endio_wait.lock);
+@@ -2377,7 +2378,7 @@ static void integrity_recalc(struct work_struct *w)
+ 
+ next_chunk:
+ 
+-	if (unlikely(READ_ONCE(ic->suspending)))
++	if (unlikely(dm_suspended(ic->ti)))
+ 		goto unlock_ret;
+ 
+ 	range.logical_sector = le64_to_cpu(ic->sb->recalc_sector);
+@@ -2805,8 +2806,6 @@ static void dm_integrity_postsuspend(struct dm_target *ti)
+ 
+ 	del_timer_sync(&ic->autocommit_timer);
+ 
+-	WRITE_ONCE(ic->suspending, 1);
+-
+ 	if (ic->recalc_wq)
+ 		drain_workqueue(ic->recalc_wq);
+ 
+@@ -2835,8 +2834,6 @@ static void dm_integrity_postsuspend(struct dm_target *ti)
+ #endif
+ 	}
+ 
+-	WRITE_ONCE(ic->suspending, 0);
+-
+ 	BUG_ON(!RB_EMPTY_ROOT(&ic->in_progress));
+ 
+ 	ic->journal_uptodate = true;
+@@ -3631,6 +3628,7 @@ static int dm_integrity_ctr(struct dm_target *ti, unsigned argc, char **argv)
+ 	}
+ 	ti->private = ic;
+ 	ti->per_io_data_size = sizeof(struct dm_integrity_io);
++	ic->ti = ti;
+ 
+ 	ic->in_progress = RB_ROOT;
+ 	INIT_LIST_HEAD(&ic->wait_list);
+diff --git a/drivers/md/dm-writecache.c b/drivers/md/dm-writecache.c
+index b9e27e37a943..8d45c848cbe4 100644
+--- a/drivers/md/dm-writecache.c
++++ b/drivers/md/dm-writecache.c
+@@ -842,7 +842,7 @@ static void writecache_suspend(struct dm_target *ti)
+ 	}
+ 	wc_unlock(wc);
+ 
+-	flush_workqueue(wc->writeback_wq);
++	drain_workqueue(wc->writeback_wq);
+ 
+ 	wc_lock(wc);
+ 	if (flush_on_suspend)
+diff --git a/drivers/md/dm.c b/drivers/md/dm.c
+index b89f07ee2eff..d01ad6a35dd0 100644
+--- a/drivers/md/dm.c
++++ b/drivers/md/dm.c
+@@ -2368,6 +2368,7 @@ static void __dm_destroy(struct mapped_device *md, bool wait)
+ 	map = dm_get_live_table(md, &srcu_idx);
+ 	if (!dm_suspended_md(md)) {
+ 		dm_table_presuspend_targets(map);
++		set_bit(DMF_SUSPENDED, &md->flags);
+ 		dm_table_postsuspend_targets(map);
+ 	}
+ 	/* dm_put_live_table must be before msleep, otherwise deadlock is possible */
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-vanilla_5.10.%.bbappend
+++ b/recipes-kernel/linux/linux-vanilla_5.10.%.bbappend
@@ -1,4 +1,5 @@
 SRC_URI += "\
+        file://0001-dm-integrity-Generate-audit-events-for-integrity-vio.patch \
 "
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"

--- a/recipes-kernel/linux/linux-vanilla_5.4.%.bbappend
+++ b/recipes-kernel/linux/linux-vanilla_5.4.%.bbappend
@@ -81,6 +81,8 @@ SRC_URI += "\
 	file://5.4/0016-audit-check-contid-count-per-netns-and-add-config-pa.patch \
 	file://5.4/0017-audit-add-capcontid-to-set-contid-outside-init_user_.patch \
 	file://5.4/0001-audit-allow-audit-in-userns.patch \
+	file://5.4/0001-dm-report-suspended-device-during-destroy.patch \
+	file://0001-dm-integrity-Generate-audit-events-for-integrity-vio.patch \
 "
 
 


### PR DESCRIPTION
Use the wip patch for dm-integrity to generate audit events in
case of integrity violations (io errors).

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>