### PR TITLE
meta-trustx/trustx-cml-initramfs: Add iw tool

### DIFF
--- a/images/trustx-cml-initramfs.bb
+++ b/images/trustx-cml-initramfs.bb
@@ -18,6 +18,7 @@ PACKAGE_INSTALL = "\
 	${ROOTFS_BOOTSTRAP_INSTALL} \
 	cml-boot \
 	iproute2 \
+	iw \
 	lxcfs \
 	pv \
 	uid-wrapper \


### PR DESCRIPTION
This commit adds the iw tool to the initramfs image to ease debugging

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>