### PR TITLE
classes: Fixed signing error in trustmegeneric.bbclass

### DIFF
--- a/classes/trustmegeneric.bbclass
+++ b/classes/trustmegeneric.bbclass
@@ -188,7 +188,7 @@ do_build_trustmeimage () {
 	# sign container configs
 	find "${rootfs_datadir}/cml/containers_templates" -name '*.conf' -exec bash \
 		${enrollment_dir}/config_creator/sign_config.sh {} \
-		${TEST_CERT_DIR}/ssig.key ${TEST_CERT_DIR}/ssig.cert \;
+		${TEST_CERT_DIR}/ssig_cml.key ${TEST_CERT_DIR}/ssig_cml.cert \;
 
 	# copy modules to data partition directory
 	kernelabiversion="$(cat "${STAGING_KERNEL_BUILDDIR}/kernel-abiversion")"


### PR DESCRIPTION
Fixed error when signing the container config, which has to be done with the ssig_cml.key, not the old ssig.key.